### PR TITLE
Add IP chart drilldown

### DIFF
--- a/netflow-webapp/src/lib/components/charts/IPChart.svelte
+++ b/netflow-webapp/src/lib/components/charts/IPChart.svelte
@@ -187,6 +187,10 @@ function handleChartClick(event: ChartEvent, activeElements: ActiveElement[]) {
 	}
 
 	const clickedDate = parseClickedLabel(label, groupBy);
+	if (!(clickedDate instanceof Date) || Number.isNaN(clickedDate.getTime())) {
+		console.warn('Unable to parse clicked label for drilldown', { label, groupBy });
+		return;
+	}
 	const activeLabel = fallbackIndex !== null ? getLabelFromIndex(fallbackIndex) : null;
 
 	if (groupBy === '5min') {

--- a/netflow-webapp/src/lib/components/charts/IPChart.svelte
+++ b/netflow-webapp/src/lib/components/charts/IPChart.svelte
@@ -208,16 +208,16 @@ function handleChartClick(event: ChartEvent, activeElements: ActiveElement[]) {
 	}
 
 	if (groupBy === 'date') {
-		const startOfMonth = new Date(clickedDate.getTime() - 15 * 24 * 60 * 60 * 1000);
-		const endOfMonth = new Date(clickedDate.getTime() + 16 * 24 * 60 * 60 * 1000);
-		emitDrilldown(nextGroupBy, startOfMonth, endOfMonth);
+		const rangeStart = new Date(clickedDate.getTime() - 15 * 24 * 60 * 60 * 1000);
+		const rangeEnd = new Date(clickedDate.getTime() + 16 * 24 * 60 * 60 * 1000);
+		emitDrilldown(nextGroupBy, rangeStart, rangeEnd);
 	} else if (groupBy === 'hour') {
-		const startOfWeek = new Date(clickedDate.getTime() - 3 * 24 * 60 * 60 * 1000);
-		const endOfWeek = new Date(clickedDate.getTime() + 4 * 24 * 60 * 60 * 1000);
-		emitDrilldown(nextGroupBy, startOfWeek, endOfWeek);
+		const rangeStart = new Date(clickedDate.getTime() - 3 * 24 * 60 * 60 * 1000);
+		const rangeEnd = new Date(clickedDate.getTime() + 4 * 24 * 60 * 60 * 1000);
+		emitDrilldown(nextGroupBy, rangeStart, rangeEnd);
 	} else if (groupBy === '30min') {
-		const endDate = new Date(clickedDate.getTime() + 24 * 60 * 60 * 1000);
-		emitDrilldown(nextGroupBy, clickedDate, endDate);
+		const rangeEnd = new Date(clickedDate.getTime() + 24 * 60 * 60 * 1000);
+		emitDrilldown(nextGroupBy, clickedDate, rangeEnd);
 	}
 }
 

--- a/netflow-webapp/src/lib/components/charts/IPChart.svelte
+++ b/netflow-webapp/src/lib/components/charts/IPChart.svelte
@@ -217,22 +217,18 @@ function handleChartClick(event: ChartEvent, activeElements: ActiveElement[]) {
 	}
 }
 
-	function renderChart() {
-		const canvas = chartCanvas;
-		if (!canvas) {
-			return;
-		}
+function renderChart() {
+	const selectedBuckets = buckets;
 
-		const selectedBuckets = buckets;
+	if (activeMetrics.length === 0 || selectedBuckets.length === 0) {
+		destroyChart();
+		return;
+	}
 
-		if (activeMetrics.length === 0 || selectedBuckets.length === 0) {
-			if (chart) {
-				chart.data.labels = [];
-				chart.data.datasets = [];
-				chart.update();
-			}
-			return;
-		}
+	const canvas = chartCanvas;
+	if (!canvas) {
+		return;
+	}
 
 		const bucketStarts = Array.from(
 			new Set(selectedBuckets.map((bucket) => bucket.bucketStart))
@@ -401,8 +397,11 @@ function handleChartClick(event: ChartEvent, activeElements: ActiveElement[]) {
 		const incomingMetrics = props.activeMetrics ?? DEFAULT_METRICS;
 		if (!arraysEqual(activeMetrics, incomingMetrics)) {
 			activeMetrics = [...incomingMetrics];
-			// renderChart keeps chart in sync with new metrics without re-fetching data
-			renderChart();
+			// wait for the DOM to reconcile (canvas may re-mount) before painting
+			void (async () => {
+				await tick();
+				renderChart();
+			})();
 		}
 
 		currentGranularity = filters.granularity;

--- a/netflow-webapp/src/routes/+page.svelte
+++ b/netflow-webapp/src/routes/+page.svelte
@@ -117,6 +117,8 @@
 			granularity={ipGranularity}
 			routers={selectedRouters}
 			activeMetrics={ipMetrics}
+			on:dateChange={handleDateChange}
+			on:groupByChange={handleGroupByChange}
 		/>
 	</main>
 </div>


### PR DESCRIPTION
## Summary
- add Chart.js click handling to IPChart so it mirrors the NetFlow drilldown workflow, including router/date transitions and file navigation
- emit date/group events from IPChart and wire them into the top-level page state to keep filters in sync

## Testing
- cd netflow-webapp && npm run check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive chart drilling with click-to-explore across time granularities (date → hour → 30min → 5min).
  * At the finest granularity, clicks navigate directly to a detail view via a generated path.
  * Charts emit date range and grouping events (dateChange, groupByChange) to keep the UI synchronized.
  * Page-level handlers now listen for those events to update date/grouping state.
  * Improved chart click handling and lifecycle cleanup for more stable interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->