### PR TITLE
Add drilldown history support

### DIFF
--- a/netflow-webapp/src/lib/components/charts/IPChart.svelte
+++ b/netflow-webapp/src/lib/components/charts/IPChart.svelte
@@ -34,13 +34,14 @@ const dispatch = createEventDispatcher<{
 	groupByChange: { groupBy: GroupByOption };
 }>();
 
-	const props = $props<{
-		startDate?: string;
-		endDate?: string;
-		granularity?: IpGranularity;
-		routers?: RouterConfig;
-		activeMetrics?: IpMetricKey[];
-	}>();
+const props = $props<{
+	startDate?: string;
+	endDate?: string;
+	granularity?: IpGranularity;
+	routers?: RouterConfig;
+	activeMetrics?: IpMetricKey[];
+	onDrilldownStart?: () => void;
+}>();
 	const today = new Date();
 	const formatDate = (date: Date): string => new Date(date).toISOString().slice(0, 10);
 	const getStartDate = () => props.startDate ?? '2025-01-01';
@@ -206,6 +207,8 @@ function handleChartClick(event: ChartEvent, activeElements: ActiveElement[]) {
 	if (!nextGroupBy) {
 		return;
 	}
+
+	props.onDrilldownStart?.();
 
 	if (groupBy === 'date') {
 		const rangeStart = new Date(clickedDate.getTime() - 15 * 24 * 60 * 60 * 1000);

--- a/netflow-webapp/src/lib/components/netflow/NetflowDashboard.svelte
+++ b/netflow-webapp/src/lib/components/netflow/NetflowDashboard.svelte
@@ -11,13 +11,14 @@
 		RouterConfig
 	} from './types.ts';
 
-	const props = $props<{
-		startDate: string;
-		endDate: string;
-		groupBy: GroupByOption;
-		routers: RouterConfig;
-		dataOptions: DataOption[];
-	}>();
+const props = $props<{
+	startDate: string;
+	endDate: string;
+	groupBy: GroupByOption;
+	routers: RouterConfig;
+	dataOptions: DataOption[];
+	onDrilldownStart?: () => void;
+}>();
 
 	const dispatch = createEventDispatcher<{
 		dateChange: { startDate: string; endDate: string };
@@ -90,10 +91,11 @@
 		}
 	}
 
-	function handleDrillDown(newGroupBy: GroupByOption, newStartDate: string, newEndDate: string) {
-		dispatch('groupByChange', { groupBy: newGroupBy });
-		dispatch('dateChange', { startDate: newStartDate, endDate: newEndDate });
-	}
+function handleDrillDown(newGroupBy: GroupByOption, newStartDate: string, newEndDate: string) {
+	props.onDrilldownStart?.();
+	dispatch('groupByChange', { groupBy: newGroupBy });
+	dispatch('dateChange', { startDate: newStartDate, endDate: newEndDate });
+}
 
 	function handleNavigateToFile(slug: string) {
 		goto(`/api/netflow/files/${slug}`);


### PR DESCRIPTION
## Summary
- capture NetFlow dashboard and IP chart filters before each drilldown and push them into browser history
- listen for popstate events to restore dates, routers, metrics, and granularity so the back button reverses drilldowns
- updated Svelte bindings to use runes-friendly / for reactive state management

## Testing
- cd netflow-webapp && npm run check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Full browser history support: back/forward navigation now properly tracks and restores complete app state and chart interactions
  * All user selections including data filters, date ranges, and drill-down actions are automatically recorded in browser history
  * Users can seamlessly navigate through previous data views and easily undo chart drill-downs using the back button

<!-- end of auto-generated comment: release notes by coderabbit.ai -->