### PR TITLE
Auto-range IP DB ingestion

### DIFF
--- a/netflow-db/ip_db.py
+++ b/netflow-db/ip_db.py
@@ -52,7 +52,6 @@ FIRST_RUN = os.environ.get('FIRST_RUN', 'False').lower() in ('true', '1', 'yes')
 MAX_WORKERS = int(os.environ.get('MAX_WORKERS', '8'))
 BATCH_SIZE = int(os.environ.get('BATCH_SIZE', '50'))
 DATA_START_DATE = datetime(2024, 3, 1)
-DATA_START_DATE = datetime(2024, 3, 1)
 
 def init_database():
 

--- a/netflow-db/ip_db.py
+++ b/netflow-db/ip_db.py
@@ -191,7 +191,7 @@ def process_day(task):
             if end_time - start_day >= timedelta(days=1):
                 results[buckets["1d"]].write_result(end_time - timedelta(days=1), end_time, conn)
         
-    return 0
+        return 0
 
 
 def determine_start_day():


### PR DESCRIPTION
## Summary
- derive IP ingestion start/end days the same way flow_db.py does, resuming from the newest 5m bucket or the initial dataset date
- rework the day worker to respect arbitrary start/end boundaries and only write complete day aggregates
- write epoch seconds as integers for bucket bounds to match downstream consumers

## Testing
- (not run)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added multi-day processing windows, parallelized tasks, and more granular incremental bucket processing (5m, 30m, 1h, 1d).
  * Improved logging and safeguards to skip processing when no completed days exist.

* **Bug Fixes**
  * Daily aggregates now emitted only after a full day is complete.
  * Timestamps stored with consistent integer precision to improve accuracy.

* **Performance**
  * More efficient window calculations and per-bucket incremental updates for faster throughput.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->