### PR TITLE
Show IPv4/IPv6 IP counts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ vite.config.ts.timestamp-*
 # Database ## Untracked due to size
 *.db*
 *.log
+
+**/local-notes

--- a/netflow-webapp/src/routes/api/netflow/files/[slug]/+page.svelte
+++ b/netflow-webapp/src/routes/api/netflow/files/[slug]/+page.svelte
@@ -28,8 +28,6 @@ type IPCounts = {
 	ipv4Count: number | null;
 	ipv6Count: number | null;
 };
-	let loadingIPCountsSource = $state(new Map<string, boolean>());
-let loadingIPCountsDestination = $state(new Map<string, boolean>());
 let IPCountsSource = $state(new Map<string, IPCounts>());
 let IPCountsDestination = $state(new Map<string, IPCounts>());
 	const formatCount = (value: number | null | undefined) => {

--- a/netflow-webapp/src/routes/api/netflow/files/[slug]/+page.svelte
+++ b/netflow-webapp/src/routes/api/netflow/files/[slug]/+page.svelte
@@ -71,18 +71,7 @@ let IPCountsDestination = $state(new Map<string, IPCounts>());
 		await Promise.all(tasks);
 	});
 
-	function setIpCountLoading(router: string, source: boolean, value: boolean) {
-		if (source) {
-			loadingIPCountsSource.set(router, value);
-			loadingIPCountsSource = new Map(loadingIPCountsSource);
-		} else {
-			loadingIPCountsDestination.set(router, value);
-			loadingIPCountsDestination = new Map(loadingIPCountsDestination);
-		}
-	}
-
 	async function loadIPCounts(router: string, source: boolean) {
-		setIpCountLoading(router, source, true);
 		try {
 			const response = await fetch(
 				`/api/netflow/files/${data.slug}/ip-counts?router=${encodeURIComponent(router)}&source=${source}`
@@ -104,8 +93,6 @@ let IPCountsDestination = $state(new Map<string, IPCounts>());
 				`Failed to load IP counts for ${router} (${source ? 'source' : 'destination'}):`,
 				e
 			);
-		} finally {
-			setIpCountLoading(router, source, false);
 		}
 	}
 
@@ -335,27 +322,13 @@ let IPCountsDestination = $state(new Map<string, IPCounts>());
 					<div class="grid grid-cols-1 gap-2 text-sm md:grid-cols-2">
 						<div>
 							<h3 class="text-md font-semibold">Unique IP Count (Source)</h3>
-							{#if loadingIPCountsSource.get(record.router)}
-								<div class="text-gray-600">Loading...</div>
-							{:else if IPCountsSource.get(record.router)}
-								{@const ipCountsSource = IPCountsSource.get(record.router)}
-								<div>IPv4: {formatCount(ipCountsSource?.ipv4Count)}</div>
-								<div>IPv6: {formatCount(ipCountsSource?.ipv6Count)}</div>
-							{:else}
-								<div class="text-gray-500">No IP stats available.</div>
-							{/if}
+							<div>IPv4: {formatCount(IPCountsSource.get(record.router)?.ipv4Count)}</div>
+							<div>IPv6: {formatCount(IPCountsSource.get(record.router)?.ipv6Count)}</div>
 						</div>
 						<div>
 							<h3 class="text-md font-semibold">Unique IP Count (Destination)</h3>
-							{#if loadingIPCountsDestination.get(record.router)}
-								<div class="text-gray-600">Loading...</div>
-							{:else if IPCountsDestination.get(record.router)}
-								{@const ipCountsDestination = IPCountsDestination.get(record.router)}
-								<div>IPv4: {formatCount(ipCountsDestination?.ipv4Count)}</div>
-								<div>IPv6: {formatCount(ipCountsDestination?.ipv6Count)}</div>
-							{:else}
-								<div class="text-gray-500">No IP stats available.</div>
-							{/if}
+							<div>IPv4: {formatCount(IPCountsDestination.get(record.router)?.ipv4Count)}</div>
+							<div>IPv6: {formatCount(IPCountsDestination.get(record.router)?.ipv6Count)}</div>
 						</div>
 					</div>
 					<div class="grid grid-cols-4 gap-4 text-sm">

--- a/netflow-webapp/src/routes/api/netflow/files/[slug]/ip-counts/+server.ts
+++ b/netflow-webapp/src/routes/api/netflow/files/[slug]/ip-counts/+server.ts
@@ -1,30 +1,39 @@
 import { json } from '@sveltejs/kit';
-import { exec } from 'child_process';
-import { promisify } from 'util';
-import { getNetflowFilePath } from '../utils';
 import type { RequestHandler } from './$types';
+import { getDb } from '../utils';
 
-const execAsync = promisify(exec);
+const FIVE_MINUTES = '5m';
 
-async function getUniqueIPCount(filePath: string, isSource: boolean): Promise<number> {
-	const command = `nfdump -r "${filePath}"  -o 'fmt:${isSource ? '%sa' : '%da'}' -q -s ${isSource ? 'srcip' : 'dstip'} -n 0 | wc -l`;
-	const { stdout } = await execAsync(command, {
-		maxBuffer: 10 * 1024 * 1024 * 10,
-		timeout: 60_000
-	});
-	const uniqueIPs = parseInt(stdout.trim());
-	return uniqueIPs;
+function slugToBucketStart(slug: string): number | null {
+	if (slug.length !== 12) {
+		return null;
+	}
+	const year = Number(slug.slice(0, 4));
+	const month = Number(slug.slice(4, 6)) - 1;
+	const day = Number(slug.slice(6, 8));
+	const hour = Number(slug.slice(8, 10));
+	const minute = Number(slug.slice(10, 12));
+
+	if (
+		Number.isNaN(year) ||
+		Number.isNaN(month) ||
+		Number.isNaN(day) ||
+		Number.isNaN(hour) ||
+		Number.isNaN(minute)
+	) {
+		return null;
+	}
+
+	const date = new Date(Date.UTC(year, month, day, hour, minute));
+	return Math.floor(date.getTime() / 1000);
 }
 
-async function getTotalIPCount(filePath: string, isSource: boolean): Promise<number> {
-	const command = `nfdump -r "${filePath}" -o 'fmt:${isSource ? '%sa' : '%da'}' -q -n 0 | wc -l`;
-	const { stdout } = await execAsync(command, {
-		maxBuffer: 10 * 1024 * 1024 * 10,
-		timeout: 60_000
-	});
-	const totalIPs = parseInt(stdout.trim());
-	return totalIPs;
-}
+type IpCountRow = {
+	saIpv4Count: number;
+	daIpv4Count: number;
+	saIpv6Count: number;
+	daIpv6Count: number;
+};
 
 export const GET: RequestHandler = async ({ params, url }) => {
 	const { slug } = params;
@@ -47,31 +56,43 @@ export const GET: RequestHandler = async ({ params, url }) => {
 	}
 
 	const isSource = sourceParam === 'true';
+	const bucketStart = slugToBucketStart(slug);
+
+	if (bucketStart === null) {
+		return json({ error: 'Unable to parse slug timestamp' }, { status: 400 });
+	}
 
 	try {
-		console.log(
-			`Getting unique IP count for ${router} - ${slug} (${isSource ? 'source' : 'destination'})`
-		);
+		const db = getDb();
+		const row = db
+			.prepare(
+				`SELECT
+					sa_ipv4_count AS saIpv4Count,
+					da_ipv4_count AS daIpv4Count,
+					sa_ipv6_count AS saIpv6Count,
+					da_ipv6_count AS daIpv6Count
+				FROM ip_stats
+				WHERE router = ?
+					AND granularity = ?
+					AND bucket_start = ?
+				LIMIT 1`
+			)
+			.get(router, FIVE_MINUTES, bucketStart) as IpCountRow | undefined;
 
-		// Get the absolute file path for the NetFlow file from the database
-		const filePath = await getNetflowFilePath(slug, router);
-		if (!filePath) {
+		if (!row) {
 			return json(
-				{ error: `NetFlow file not found for router ${router} and slug ${slug}` },
+				{ error: `IP statistics not found for router ${router} at ${slug}` },
 				{ status: 404 }
 			);
 		}
 
-		console.log(`Found NetFlow file: ${filePath}`);
+		const response = isSource
+			? { ipv4Count: row.saIpv4Count, ipv6Count: row.saIpv6Count }
+			: { ipv4Count: row.daIpv4Count, ipv6Count: row.daIpv6Count };
 
-		const [uniqueIPCount, totalIPCount] = await Promise.all([
-			getUniqueIPCount(filePath, isSource),
-			getTotalIPCount(filePath, isSource)
-		]);
-
-		return json({ uniqueIPCount, totalIPCount });
+		return json(response);
 	} catch (error) {
-		console.error(error);
+		console.error('Failed to fetch IP counts from database:', error);
 		return json({ error: 'Failed to get IP counts' }, { status: 500 });
 	}
 };

--- a/netflow-webapp/src/routes/api/netflow/files/[slug]/ip-counts/+server.ts
+++ b/netflow-webapp/src/routes/api/netflow/files/[slug]/ip-counts/+server.ts
@@ -24,7 +24,7 @@ function slugToBucketStart(slug: string): number | null {
 		return null;
 	}
 
-	const date = new Date(Date.UTC(year, month, day, hour, minute));
+	const date = new Date(year, month, day, hour, minute);
 	return Math.floor(date.getTime() / 1000);
 }
 


### PR DESCRIPTION
## Summary
- swap the ip-counts endpoint to read directly from the ip_stats table and return IPv4/IPv6 counts for the 5-minute slug bucket
- adjust the file detail UI to show IPv4/IPv6 unique counts (blank until data loads) instead of unique/total ratios
- ensure slug timestamps map to the correct local bucket so counts align with the charts

## Testing
- cd netflow-webapp && npm run check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * IP count metrics now show IPv4 and IPv6 separately for source and destination, with a responsive grid layout.
  * Counts display "N/A" when unavailable and loading behavior has been made more consistent.
  * Backend now serves pre-aggregated 5-minute statistics for more reliable and timely IP counts.

* **Bug Fixes**
  * Clearer error responses when requested IP statistics are missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->