### PR TITLE
feat(charts): consistent spacing for y-axis

### DIFF
--- a/netflow-webapp/src/lib/components/charts/ChartContainer.svelte
+++ b/netflow-webapp/src/lib/components/charts/ChartContainer.svelte
@@ -8,7 +8,8 @@
 		formatLabels,
 		getXAxisTitle,
 		parseClickedLabel,
-		generateSlugFromLabel
+		generateSlugFromLabel,
+		Y_AXIS_WIDTH
 	} from './chart-utils';
 	import {
 		parseLabelToPSTComponents,
@@ -366,6 +367,9 @@
 						type: 'linear',
 						stacked: true,
 						beginAtZero: true,
+						afterFit(axis: { width: number }) {
+							axis.width = Y_AXIS_WIDTH;
+						},
 						title: {
 							display: true,
 							text: 'Value'
@@ -398,6 +402,9 @@
 						type: 'logarithmic',
 						beginAtZero: true,
 						min: 1,
+						afterFit(axis: { width: number }) {
+							axis.width = Y_AXIS_WIDTH;
+						},
 						title: {
 							display: true,
 							text: 'Value (Log Scale)'
@@ -506,6 +513,11 @@
 								: 'rgba(0,0,0,0.02)';
 						}
 					}
+					},
+					y: {
+						afterFit(axis: { width: number }) {
+							axis.width = Y_AXIS_WIDTH;
+						}
 					}
 				},
 				plugins: {

--- a/netflow-webapp/src/lib/components/charts/IPChart.svelte
+++ b/netflow-webapp/src/lib/components/charts/IPChart.svelte
@@ -13,7 +13,7 @@
 		type IpStatsBucket,
 		type IpStatsResponse
 	} from '$lib/types/types';
-	import { generateSlugFromLabel, parseClickedLabel } from './chart-utils';
+	import { generateSlugFromLabel, parseClickedLabel, formatNumber, Y_AXIS_WIDTH } from './chart-utils';
 	import {
 		dateStringToEpochPST,
 		epochToPSTComponents,
@@ -382,9 +382,15 @@
 						},
 						y: {
 							beginAtZero: true,
+							afterFit(axis: { width: number }) {
+								axis.width = Y_AXIS_WIDTH;
+							},
 							title: {
 								display: true,
 								text: 'Unique IPs'
+							},
+							ticks: {
+								callback: (value: string | number) => formatNumber(Number(value))
 							}
 						}
 					}
@@ -413,7 +419,13 @@
 				},
 				y: {
 					...chart.options.scales?.y,
-					title: { display: true, text: 'Unique IPs' }
+					afterFit(axis: { width: number }) {
+						axis.width = Y_AXIS_WIDTH;
+					},
+					title: { display: true, text: 'Unique IPs' },
+					ticks: {
+						callback: (value: string | number) => formatNumber(Number(value))
+					}
 				}
 			};
 			chart.options.onClick = handleChartClick;

--- a/netflow-webapp/src/lib/components/charts/ProtocolChart.svelte
+++ b/netflow-webapp/src/lib/components/charts/ProtocolChart.svelte
@@ -11,7 +11,7 @@
 		type ProtocolStatsBucket,
 		type ProtocolStatsResponse
 	} from '$lib/types/types';
-	import { parseClickedLabel, generateSlugFromLabel } from './chart-utils';
+	import { parseClickedLabel, generateSlugFromLabel, Y_AXIS_WIDTH } from './chart-utils';
 	import {
 		dateStringToEpochPST,
 		epochToPSTComponents,
@@ -350,7 +350,13 @@
 										: 'rgba(0,0,0,0.02)'
 							}
 						},
-						y: { beginAtZero: true, title: { display: true, text: 'Unique Protocols' } }
+						y: {
+							beginAtZero: true,
+							afterFit(axis: { width: number }) {
+								axis.width = Y_AXIS_WIDTH;
+							},
+							title: { display: true, text: 'Unique Protocols' }
+						}
 					}
 				}
 			});
@@ -375,7 +381,13 @@
 								: 'rgba(0,0,0,0.02)'
 					}
 				},
-				y: { ...chart.options.scales?.y, title: { display: true, text: 'Unique Protocols' } }
+				y: {
+					...chart.options.scales?.y,
+					afterFit(axis: { width: number }) {
+						axis.width = Y_AXIS_WIDTH;
+					},
+					title: { display: true, text: 'Unique Protocols' }
+				}
 			};
 			chart.options.onClick = handleChartClick;
 			chart.update();

--- a/netflow-webapp/src/lib/components/charts/SpectrumStatsChart.svelte
+++ b/netflow-webapp/src/lib/components/charts/SpectrumStatsChart.svelte
@@ -11,7 +11,7 @@
 		SpectrumStatsBucket,
 		SpectrumStatsResponse
 	} from '$lib/types/types';
-	import { generateSlugFromLabel, parseClickedLabel } from './chart-utils';
+	import { generateSlugFromLabel, parseClickedLabel, Y_AXIS_WIDTH } from './chart-utils';
 	import {
 		dateStringToEpochPST,
 		epochToPSTComponents,
@@ -439,6 +439,9 @@
 							type: 'linear',
 							min: minAlpha - alphaPadding,
 							max: maxAlpha + alphaPadding,
+							afterFit(axis: { width: number }) {
+								axis.width = Y_AXIS_WIDTH;
+							},
 							title: {
 								display: true,
 								text: 'alpha'
@@ -479,6 +482,9 @@
 				y: {
 					min: minAlpha - alphaPadding,
 					max: maxAlpha + alphaPadding,
+					afterFit(axis: { width: number }) {
+						axis.width = Y_AXIS_WIDTH;
+					},
 					title: { display: true, text: 'alpha' }
 				} as never
 			};

--- a/netflow-webapp/src/lib/components/charts/chart-utils.ts
+++ b/netflow-webapp/src/lib/components/charts/chart-utils.ts
@@ -6,6 +6,9 @@ import {
 	type PSTDateComponents
 } from '$lib/utils/timezone';
 
+/** Fixed y-axis width (px) for consistent chart alignment */
+export const Y_AXIS_WIDTH = 80;
+
 export function formatLabels(results: NetflowDataPoint[], groupBy: GroupByOption): string[] {
 	switch (groupBy) {
 		case 'date':


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR implements consistent y-axis spacing across all chart components by centralizing the axis width configuration. A new `Y_AXIS_WIDTH` constant (80px) is exported from `chart-utils.ts` and applied uniformly to ChartContainer, IPChart, ProtocolChart, and SpectrumStatsChart using Chart.js's `afterFit` callback pattern. Additionally, IPChart now includes number formatting for y-axis ticks to improve readability of IP count values.

**Changes Made:**
- Extracted fixed y-axis width (80px) into a reusable constant in chart-utils
- Applied `afterFit` callbacks to y-axis configurations in all four chart components
- Added number formatting for IPChart y-axis ticks for better UX
- Maintained consistency across both chart initialization and update code paths

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no identified issues - straightforward refactoring that improves chart consistency.
- The PR implements a well-scoped improvement for consistent y-axis spacing. All changes are additive (new constant, new `afterFit` callbacks) with no breaking changes. The constant is properly exported and consistently imported across all affected components. Both initialization and update code paths are handled uniformly. The pattern follows Chart.js best practices. No type errors, logic issues, or style violations detected. The bonus improvement of adding number formatting to IPChart is a solid enhancement with no negative side effects.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| netflow-webapp/src/lib/components/charts/chart-utils.ts | Added `Y_AXIS_WIDTH` constant (80px) as a centralized export for consistent y-axis width across all charts. Properly documented with comment. No issues found. |
| netflow-webapp/src/lib/components/charts/ChartContainer.svelte | Imports and applies `Y_AXIS_WIDTH` constant to three y-axis configurations: stacked linear scale, logarithmic scale, and initial chart setup. Each uses `afterFit` callback to set consistent width. Implementation is correct and follows Chart.js patterns. |
| netflow-webapp/src/lib/components/charts/IPChart.svelte | Imports `Y_AXIS_WIDTH` and `formatNumber` utility. Applies fixed y-axis width to both initial chart creation and update paths. Also adds number formatting callback for y-axis ticks, improving readability of IP count values. Changes are consistently applied. |
| netflow-webapp/src/lib/components/charts/ProtocolChart.svelte | Imports and applies `Y_AXIS_WIDTH` constant to y-axis in both chart initialization and update code paths. Properly sets fixed width for consistent protocol chart alignment. Implementation matches pattern from other chart components. |
| netflow-webapp/src/lib/components/charts/SpectrumStatsChart.svelte | Imports and applies `Y_AXIS_WIDTH` constant to y-axis in both scatter chart creation and update paths. Ensures consistent width for spectrum alpha values visualization. Implementation is correct and follows established patterns. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant ChartComponent as Chart Component<br/>(Container/IP/Protocol/Spectrum)
    participant ChartLib as Chart.js
    participant Utils as chart-utils.ts
    
    User->>ChartComponent: Mount component or update props
    ChartComponent->>Utils: Import Y_AXIS_WIDTH constant (80px)
    ChartComponent->>ChartLib: Create chart with y-axis config
    ChartComponent->>ChartLib: Register afterFit callback
    
    Note over ChartLib: During chart rendering
    ChartLib->>ChartLib: Calculate axis dimensions
    ChartLib->>ChartComponent: Call afterFit(axis)
    ChartComponent->>ChartComponent: axis.width = Y_AXIS_WIDTH
    ChartLib->>ChartLib: Render chart with fixed 80px width
    
    User->>ChartComponent: Update data/granularity
    ChartComponent->>ChartComponent: Call renderChart()
    ChartComponent->>ChartLib: Update chart.options.scales
    ChartComponent->>ChartLib: Re-register afterFit callback
    ChartLib->>ChartComponent: Call afterFit(axis) on update
    ChartComponent->>ChartComponent: axis.width = Y_AXIS_WIDTH
    ChartLib->>ChartLib: Re-render with consistent width
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->