### PR TITLE
fix(charts): timezones accounted for and lint fixed

### DIFF
--- a/netflow-webapp/eslint.config.js
+++ b/netflow-webapp/eslint.config.js
@@ -35,6 +35,6 @@ export default ts.config(
 		}
 	},
 	{
-		ignores: ['.svelte-kit/**']
+		ignores: ['.svelte-kit/**', 'build/**']
 	}
 );

--- a/netflow-webapp/src/lib/components/charts/SpectrumStatsChart.svelte
+++ b/netflow-webapp/src/lib/components/charts/SpectrumStatsChart.svelte
@@ -3,7 +3,7 @@
 	import { goto } from '$app/navigation';
 	import { Chart, registerables } from 'chart.js/auto';
 	import { getRelativePosition } from 'chart.js/helpers';
-	import type { ActiveElement, ChartEvent } from 'chart.js';
+	import type { ActiveElement, ChartEvent, TooltipItem } from 'chart.js';
 	import type { GroupByOption, RouterConfig } from '$lib/components/netflow/types.ts';
 	import type {
 		IpGranularity,
@@ -402,13 +402,13 @@
 						tooltip: {
 							enabled: true,
 							callbacks: {
-								title: (items) => {
+								title: (items: TooltipItem<'scatter'>[]) => {
 									const item = items[0];
 									if (!item) return '';
 									const dataIndex = item.dataIndex;
 									return data[dataIndex]?.timeLabel ?? '';
 								},
-								label: (context) => {
+								label: (context: TooltipItem<'scatter'>) => {
 									const dataIndex = context.dataIndex;
 									const point = data[dataIndex];
 									if (!point) return '';
@@ -575,22 +575,6 @@
 		destroyChart();
 	});
 
-	// Compute f range for color scale legend
-	const fRange = $derived.by(() => {
-		if (buckets.length === 0) return { min: 0, max: 0 };
-		let minF = Infinity;
-		let maxF = -Infinity;
-		buckets.forEach((bucket) => {
-			const points = addressType === 'sa' ? bucket.spectrumSa : bucket.spectrumDa;
-			points.forEach((point) => {
-				minF = Math.min(minF, point.f);
-				maxF = Math.max(maxF, point.f);
-			});
-		});
-		if (minF === Infinity) return { min: 0, max: 0 };
-		return { min: minF, max: maxF };
-	});
-
 	let currentGranularity = $state<IpGranularity>(props.granularity ?? '1h');
 
 	$effect(() => {
@@ -668,18 +652,6 @@
 				</button>
 			</div>
 		</div>
-		{#if buckets.length > 0 && fRange.max > fRange.min}
-			<div class="mt-2 flex items-center gap-2 text-xs text-gray-600">
-				<span>f = {fRange.min.toFixed(6)}</span>
-				<div class="flex h-4 w-32 items-center rounded border border-gray-300">
-					<div
-						class="h-full w-full rounded"
-						style="background: linear-gradient(to right, hsl(270, 70%, 50%), hsl(60, 70%, 50%))"
-					></div>
-				</div>
-				<span>f = {fRange.max.toFixed(6)}</span>
-			</div>
-		{/if}
 	</div>
 	<div class="p-4">
 		<div

--- a/netflow-webapp/src/lib/components/netflow/NetflowDashboard.svelte
+++ b/netflow-webapp/src/lib/components/netflow/NetflowDashboard.svelte
@@ -3,6 +3,7 @@
 	import { goto } from '$app/navigation';
 	import ChartContainer from '$lib/components/charts/ChartContainer.svelte';
 	import ChartControls from '$lib/components/charts/ChartControls.svelte';
+	import { dateStringToEpochPST } from '$lib/utils/timezone';
 	import type {
 		DataOption,
 		GroupByOption,
@@ -52,8 +53,8 @@
 		error = null;
 
 		const params = new URLSearchParams({
-			startDate: Math.floor(new Date(filters.startDate).getTime() / 1000).toString(),
-			endDate: Math.floor(new Date(filters.endDate).getTime() / 1000).toString(),
+			startDate: dateStringToEpochPST(filters.startDate).toString(),
+			endDate: dateStringToEpochPST(filters.endDate, true).toString(),
 			routers: activeRouters.join(','),
 			dataOptions: dataOptionsToBinary(filters.dataOptions).toString(),
 			groupBy: filters.groupBy

--- a/netflow-webapp/src/lib/stores/netflow.svelte.ts
+++ b/netflow-webapp/src/lib/stores/netflow.svelte.ts
@@ -6,6 +6,7 @@ import type {
 	DataOption,
 	RouterConfig
 } from '$lib/components/netflow/types.ts';
+import { dateStringToEpochPST } from '$lib/utils/timezone';
 
 class NetflowStore {
 	private _state = $state<ChartState>({
@@ -200,9 +201,9 @@ class NetflowStore {
 		try {
 			const response = await fetch(
 				'/api/netflow/stats?startDate=' +
-					Math.floor(new Date(this._state.startDate).getTime() / 1000) +
+					dateStringToEpochPST(this._state.startDate) +
 					'&endDate=' +
-					Math.floor(new Date(this._state.endDate).getTime() / 1000) +
+					dateStringToEpochPST(this._state.endDate, true) +
 					'&routers=' +
 					this.activeRouters +
 					'&dataOptions=' +

--- a/netflow-webapp/svelte.config.js
+++ b/netflow-webapp/svelte.config.js
@@ -1,4 +1,4 @@
-import adapter from '@sveltejs/adapter-auto';
+import adapter from '@sveltejs/adapter-node';
 import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 
 /** @type {import('@sveltejs/kit').Config} */


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Refactored timezone handling to use epoch timestamps throughout the data pipeline, with frontend using `Intl` API for PST/PDT-aware display formatting. Added TypeScript types to Chart.js tooltip callbacks and removed unused color scale legend. Updated build configuration to use explicit Node.js adapter and ignore build directory in ESLint.

**Key Changes:**
- Backend now returns epoch timestamps instead of formatted date strings, with SQL bucketing using fixed PST offset
- Frontend uses `epochToPSTComponents()` and `dateStringToEpochPST()` utilities for consistent timezone conversion
- Simplified `formatLabels()` to handle all `groupBy` options uniformly using epoch parsing
- Removed dead code (`fRange` calculation and color scale legend in `SpectrumStatsChart.svelte`)

**Critical Issue:**
- Backend bucketing uses a fixed 8-hour PST offset, which will cause incorrect time bucketing during PDT (March-November when offset is 7 hours). This means data could be grouped into wrong hour/day buckets during daylight saving time.

<h3>Confidence Score: 2/5</h3>


- This PR contains a critical timezone bug that will cause data bucketing errors during daylight saving time
- The frontend timezone handling is correct and well-implemented using the Intl API. However, the backend SQL bucketing logic uses a fixed 8-hour PST offset that doesn't account for PDT (7-hour offset during daylight saving time). This will cause timestamps to be bucketed incorrectly from March to November, potentially grouping data into wrong hours or days. The lint fixes and config changes are solid.
- Pay close attention to `netflow-webapp/src/routes/api/netflow/stats/+server.ts` - the bucketing logic needs DST handling

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| netflow-webapp/src/routes/api/netflow/stats/+server.ts | Backend timezone bucketing refactored to use epoch calculations, but uses fixed PST offset that won't handle PDT correctly |
| netflow-webapp/src/lib/components/charts/chart-utils.ts | Refactored label formatting to use epoch timestamps with PST conversion via Intl API |
| netflow-webapp/src/lib/components/charts/SpectrumStatsChart.svelte | Added TypeScript types to tooltip callbacks and removed unused color scale legend code |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User as User Browser
    participant Dashboard as NetflowDashboard
    participant API as /api/netflow/stats
    participant DB as SQLite Database
    participant ChartUtils as chart-utils.ts
    participant Chart as Chart.js

    User->>Dashboard: Select date range (YYYY-MM-DD)
    Dashboard->>Dashboard: dateStringToEpochPST(startDate)
    Dashboard->>Dashboard: dateStringToEpochPST(endDate, true)
    Note over Dashboard: Converts PST date strings<br/>to epoch timestamps<br/>using Intl API (handles DST)
    
    Dashboard->>API: GET /api/netflow/stats?startDate={epoch}&endDate={epoch}&groupBy=...
    
    API->>API: getBucketStartQuery(groupBy)
    Note over API: Creates SQL expression with<br/>FIXED 8-hour PST offset<br/>(ISSUE: breaks during PDT)
    
    API->>DB: Query with bucket calculation:<br/>(timestamp + 28800) / bucket_size * bucket_size - 28800
    DB-->>API: Returns rows with bucket_start (epoch)
    
    API-->>Dashboard: JSON: [{time: "epoch_string", data: "..."}]
    
    Dashboard->>ChartUtils: formatLabels(results, groupBy)
    ChartUtils->>ChartUtils: epochToPSTComponents(epoch)
    Note over ChartUtils: Converts epoch to PST<br/>using Intl API (handles DST)
    ChartUtils-->>Dashboard: ["YYYY-MM-DD HH:mm", ...]
    
    Dashboard->>Chart: Render chart with formatted labels
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->