### PR TITLE
chore(git): ignore local exploration artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,5 +26,6 @@ vite.config.ts.timestamp-*
 # Database ## Untracked due to size
 *.db*
 *.log
+exploration/
 
 **/local-notes


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Added `exploration/` directory pattern to `.gitignore` to prevent local exploration artifacts from being tracked in version control.

This change aligns with the repository's existing pattern of excluding local development artifacts (like `**/local-notes`) and large data files (database files, logs). The `exploration/` directory is appropriately placed in the database section of the gitignore file, consistent with the repository's organization conventions outlined in AGENTS.md, which emphasizes keeping binaries, SQLite files, and captures out of git.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- This is a simple and appropriate gitignore addition that follows established repository patterns. The change adds a single directory pattern to exclude local exploration artifacts, which is consistent with the project's existing approach to excluding development files and large data assets. No code logic is affected, and the change aligns with repository guidelines.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .gitignore | Added `exploration/` directory to gitignore to exclude local exploration artifacts from version control |

</details>



<sub>Last reviewed commit: 958b168</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->