### PR TITLE
Move spectrum controls into primary filters

### DIFF
--- a/netflow-webapp/src/lib/components/filters/PrimaryFilters.svelte
+++ b/netflow-webapp/src/lib/components/filters/PrimaryFilters.svelte
@@ -23,6 +23,8 @@
 		endDate: string;
 		groupBy: GroupByOption;
 		routers: RouterConfig;
+		spectrumRouter: string;
+		spectrumAddressType: 'sa' | 'da';
 		dataOptions: DataOption[];
 		ipMetrics: IpMetricKey[];
 		protocolMetrics: ProtocolMetricKey[];
@@ -34,6 +36,8 @@
 		endDateChange: { endDate: string };
 		groupByChange: { groupBy: GroupByOption };
 		routersChange: { routers: RouterConfig };
+		spectrumRouterChange: { router: string };
+		spectrumAddressTypeChange: { addressType: 'sa' | 'da' };
 		dataOptionsChange: { options: DataOption[] };
 		ipMetricsChange: { metrics: IpMetricKey[] };
 		protocolMetricsChange: { metrics: ProtocolMetricKey[] };
@@ -60,6 +64,20 @@
 		dispatch('routersChange', { routers: nextRouters });
 	}
 
+	function handleSpectrumRouterChange(router: string) {
+		if (router === props.spectrumRouter) {
+			return;
+		}
+		dispatch('spectrumRouterChange', { router });
+	}
+
+	function handleSpectrumAddressTypeChange(addressType: 'sa' | 'da') {
+		if (addressType === props.spectrumAddressType) {
+			return;
+		}
+		dispatch('spectrumAddressTypeChange', { addressType });
+	}
+
 	function handleDataOptionsChange(nextOptions: DataOption[]) {
 		dispatch('dataOptionsChange', { options: nextOptions });
 	}
@@ -81,6 +99,13 @@
 			: [...current, metric];
 		dispatch('protocolMetricsChange', { metrics });
 	}
+
+	const spectrumRouters = $derived(
+		Object.entries(props.routers)
+			.filter(([, enabled]) => enabled)
+			.map(([router]) => router)
+			.sort()
+	);
 </script>
 
 <div class="space-y-4 rounded-lg border bg-white p-4 shadow-sm">
@@ -89,7 +114,7 @@
 		<label class="text-sm text-gray-600">
 			Granularity
 			<select
-				class="ml-2 rounded border border-gray-300 bg-white px-2 py-1 text-sm text-gray-700 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+				class="ml-2 rounded border border-gray-300 bg-white px-2 py-1 text-sm text-gray-700 focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
 				value={props.groupBy}
 				onchange={handleGroupBySelect}
 				aria-label="Select aggregation granularity"
@@ -148,6 +173,57 @@
 					</span>
 				</label>
 			{/each}
+		</div>
+	</div>
+
+	<div class="space-y-2">
+		<h3 class="text-base font-semibold text-gray-900">Spectrum Metrics</h3>
+		<div class="space-y-2">
+			<div class="flex min-h-6 flex-wrap items-center gap-4">
+				{#if spectrumRouters.length === 0}
+					{#each Array(4) as _, index (index)}
+						<span class="inline-block h-4 w-24 animate-pulse rounded bg-gray-200" aria-hidden="true"
+						></span>
+					{/each}
+				{:else}
+					{#each spectrumRouters as routerName (routerName)}
+						<label class="flex cursor-pointer items-center gap-2">
+							<input
+								type="radio"
+								name="spectrum-router"
+								checked={props.spectrumRouter === routerName}
+								onchange={() => handleSpectrumRouterChange(routerName)}
+								class="h-4 w-4 border-gray-300 text-blue-600 focus:ring-blue-500"
+							/>
+							<span class="text-sm text-gray-700">{routerName}</span>
+						</label>
+					{/each}
+				{/if}
+			</div>
+		</div>
+		<div class="space-y-2">
+			<div class="flex flex-wrap items-center gap-4">
+				<label class="flex cursor-pointer items-center gap-2">
+					<input
+						type="radio"
+						name="spectrum-address-type"
+						checked={props.spectrumAddressType === 'sa'}
+						onchange={() => handleSpectrumAddressTypeChange('sa')}
+						class="h-4 w-4 border-gray-300 text-blue-600 focus:ring-blue-500"
+					/>
+					<span class="text-sm text-gray-700">Source IPv4</span>
+				</label>
+				<label class="flex cursor-pointer items-center gap-2">
+					<input
+						type="radio"
+						name="spectrum-address-type"
+						checked={props.spectrumAddressType === 'da'}
+						onchange={() => handleSpectrumAddressTypeChange('da')}
+						class="h-4 w-4 border-gray-300 text-blue-600 focus:ring-blue-500"
+					/>
+					<span class="text-sm text-gray-700">Destination IPv4</span>
+				</label>
+			</div>
 		</div>
 	</div>
 </div>

--- a/netflow-webapp/src/lib/components/filters/RouterFilter.svelte
+++ b/netflow-webapp/src/lib/components/filters/RouterFilter.svelte
@@ -7,6 +7,7 @@
 	}
 
 	let { routers, onRouterChange }: Props = $props();
+	const routerNames = $derived(Object.keys(routers));
 
 	function handleRouterToggle(routerName: string) {
 		const newRouters = {
@@ -20,15 +21,24 @@
 <div class="router-filter flex flex-wrap items-center gap-4">
 	<span class="text-sm font-medium text-gray-700">Routers:</span>
 
-	{#each Object.keys(routers) as routerName (routerName)}
-		<label class="flex cursor-pointer items-center gap-2">
-			<input
-				type="checkbox"
-				checked={routers[routerName]}
-				onchange={() => handleRouterToggle(routerName)}
-				class="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
-			/>
-			<span class="text-sm text-gray-700">{routerName}</span>
-		</label>
-	{/each}
+	<div class="flex min-h-6 flex-wrap items-center gap-4">
+		{#if routerNames.length === 0}
+			{#each Array(4) as _, index (index)}
+				<span class="inline-block h-4 w-24 animate-pulse rounded bg-gray-200" aria-hidden="true"
+				></span>
+			{/each}
+		{:else}
+			{#each routerNames as routerName (routerName)}
+				<label class="flex cursor-pointer items-center gap-2">
+					<input
+						type="checkbox"
+						checked={routers[routerName]}
+						onchange={() => handleRouterToggle(routerName)}
+						class="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+					/>
+					<span class="text-sm text-gray-700">{routerName}</span>
+				</label>
+			{/each}
+		{/if}
+	</div>
 </div>


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Refactored spectrum chart controls by moving address type and router selection from `SpectrumStatsChart` into `PrimaryFilters`, centralizing all filter controls. The chart now accepts a single router string and address type prop instead of managing these internally.

- Removed Source/Destination toggle buttons from chart component header
- Added new "Spectrum Metrics" section in primary filters with radio buttons for router selection and address type
- Spectrum router automatically syncs with enabled routers (selects first enabled router when current selection is disabled)
- Added loading skeleton states for better UX when routers are loading
- Simplified `SpectrumStatsChart` prop interface: `router` (string) and `addressType` replace `routers` (RouterConfig)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Clean refactoring that improves UI organization by consolidating controls; no logical errors, proper state management, and consistent patterns throughout
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| netflow-webapp/src/lib/components/charts/SpectrumStatsChart.svelte | Simplified props to accept single router string and addressType prop instead of RouterConfig; removed internal address type toggle buttons |
| netflow-webapp/src/lib/components/filters/PrimaryFilters.svelte | Added Spectrum Metrics section with router radio selection and address type controls; includes loading skeleton for routers |
| netflow-webapp/src/lib/components/filters/RouterFilter.svelte | Added loading skeleton state with pulse animation when no routers are available |
| netflow-webapp/src/routes/+page.svelte | Added spectrum router and address type state management with auto-selection logic when routers change; wired up new event handlers |

</details>



<h3>Flowchart</h3>

```mermaid
flowchart TD
    A[+page.svelte] -->|passes spectrumRouter & spectrumAddressType| B[PrimaryFilters]
    A -->|passes router & addressType| C[SpectrumStatsChart]
    B -->|user changes spectrum controls| D{Event Dispatched}
    D -->|spectrumRouterChange| E[Update selectedSpectrumRouter]
    D -->|spectrumAddressTypeChange| F[Update selectedSpectrumAddressType]
    E --> G[Check if router in enabled list]
    G -->|not enabled| H[Auto-select first enabled router]
    G -->|enabled| I[Keep selection]
    A -->|routersChange event| J{Router Config Changed}
    J -->|spectrum router disabled| H
    J -->|spectrum router still enabled| I
    B -->|radio buttons for router selection| K[Spectrum Metrics Section]
    B -->|radio buttons for address type| K
    K -->|derived from routers prop| L[Filter enabled routers]
    C -->|receives single router string| M[Fetch spectrum data]
    C -->|receives addressType prop| N[Display correct spectrum]
```

<sub>Last reviewed commit: 8d78459</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->