### PR TITLE
refactor(webapp): unify dashboard UI and file views

### DIFF
--- a/netflow-webapp/src/app.css
+++ b/netflow-webapp/src/app.css
@@ -1,10 +1,181 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&family=Space+Grotesk:wght@500;600;700&display=swap');
 @import 'tailwindcss';
 
 @import 'tw-animate-css';
 
 @theme {
-	--font-body: 'Inter', sans-serif;
+	--font-body: 'Manrope', sans-serif;
+	--font-display: 'Space Grotesk', sans-serif;
 
 	--color-cisco-blue: #009edc;
+}
+
+html,
+body {
+	min-height: 100%;
+}
+
+body {
+	margin: 0;
+	color: #0f172a;
+	background:
+		radial-gradient(circle at 12% 10%, rgba(6, 182, 212, 0.16), transparent 34%),
+		radial-gradient(circle at 85% 0%, rgba(14, 116, 144, 0.1), transparent 28%),
+		linear-gradient(180deg, #f4f8fb 0%, #eef3f8 52%, #f8fbfd 100%);
+}
+
+h1,
+h2,
+h3,
+h4 {
+	font-family: var(--font-display);
+	letter-spacing: -0.01em;
+}
+
+a {
+	color: inherit;
+}
+
+::selection {
+	background: rgba(14, 116, 144, 0.2);
+	color: #082f49;
+}
+
+.app-content-shell {
+	margin: 0 auto;
+	width: 100%;
+	max-width: 90rem;
+	padding: 1.5rem 1rem 2.5rem;
+}
+
+.surface-card {
+	border: 1px solid rgba(148, 163, 184, 0.3);
+	border-radius: 0.9rem;
+	background: rgba(255, 255, 255, 0.9);
+	box-shadow: 0 20px 40px -34px rgba(15, 23, 42, 0.5);
+	backdrop-filter: blur(4px);
+}
+
+.surface-card-header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 0.75rem;
+	border-bottom: 1px solid rgba(148, 163, 184, 0.24);
+	padding: 0.95rem 1rem;
+}
+
+.surface-card-body {
+	padding: 1rem;
+}
+
+.control-input {
+	border: 1px solid rgb(203, 213, 225);
+	border-radius: 0.55rem;
+	background: white;
+	padding: 0.45rem 0.6rem;
+	font-size: 0.875rem;
+	line-height: 1.25rem;
+	color: rgb(30, 41, 59);
+}
+
+.control-input:focus {
+	border-color: rgb(14, 116, 144);
+	outline: none;
+	box-shadow: 0 0 0 3px rgba(6, 182, 212, 0.18);
+}
+
+.btn-primary {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	border: 1px solid transparent;
+	border-radius: 0.6rem;
+	background: linear-gradient(135deg, #0e7490, #0369a1);
+	padding: 0.45rem 0.95rem;
+	font-size: 0.84rem;
+	font-weight: 600;
+	color: white;
+	text-decoration: none;
+	cursor: pointer;
+	transition: filter 140ms ease;
+}
+
+.btn-primary:hover {
+	filter: brightness(1.05);
+}
+
+.btn-muted {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	border: 1px solid rgba(148, 163, 184, 0.45);
+	border-radius: 0.6rem;
+	background: rgba(241, 245, 249, 0.7);
+	padding: 0.4rem 0.85rem;
+	font-size: 0.8rem;
+	font-weight: 600;
+	color: rgb(51, 65, 85);
+	text-decoration: none;
+	cursor: pointer;
+	transition:
+		background-color 120ms ease,
+		border-color 120ms ease,
+		color 120ms ease;
+}
+
+.btn-muted:hover {
+	border-color: rgba(14, 116, 144, 0.4);
+	background: rgba(224, 242, 254, 0.7);
+	color: rgb(12, 74, 110);
+}
+
+.status-panel {
+	display: flex;
+	height: 100%;
+	align-items: center;
+	justify-content: center;
+	padding: 1rem;
+	text-align: center;
+	color: rgb(71, 85, 105);
+}
+
+.status-panel-error {
+	color: rgb(185, 28, 28);
+}
+
+.chart-frame {
+	height: 340px;
+	min-height: 240px;
+	resize: vertical;
+	overflow: auto;
+	border: 1px solid rgba(148, 163, 184, 0.3);
+	border-radius: 0.75rem;
+	background: rgba(255, 255, 255, 0.92);
+}
+
+.chart-frame-tall {
+	height: 400px;
+	min-height: 300px;
+}
+
+.nav-link {
+	border-radius: 9999px;
+	padding: 0.35rem 0.8rem;
+	font-size: 0.85rem;
+	font-weight: 600;
+	color: rgb(71, 85, 105);
+	transition:
+		background-color 120ms ease,
+		color 120ms ease;
+}
+
+.nav-link:hover {
+	background: rgba(226, 232, 240, 0.8);
+	color: rgb(15, 23, 42);
+}
+
+.nav-link-active {
+	background: rgba(14, 116, 144, 0.12);
+	color: rgb(8, 47, 73);
 }

--- a/netflow-webapp/src/lib/components/charts/ChartControls.svelte
+++ b/netflow-webapp/src/lib/components/charts/ChartControls.svelte
@@ -34,16 +34,13 @@
 	}
 </script>
 
-<div class="chart-controls mb-4 flex flex-wrap gap-4 rounded-lg bg-gray-50 p-4">
+<div
+	class="chart-controls mb-4 flex flex-wrap items-center gap-3 rounded-lg border border-slate-200/70 bg-slate-50/70 p-3"
+>
 	{#if showGroupBy}
 		<div class="flex items-center gap-2">
-			<label for="groupBy" class="text-sm font-medium text-gray-700">Group by:</label>
-			<select
-				id="groupBy"
-				value={groupBy}
-				onchange={handleGroupByChange}
-				class="rounded-md border border-gray-300 px-3 py-1 text-sm focus:ring-2 focus:ring-blue-500 focus:outline-none"
-			>
+			<label for="groupBy" class="text-sm font-medium text-slate-700">Group by</label>
+			<select id="groupBy" value={groupBy} onchange={handleGroupByChange} class="control-input">
 				<option value="date">Date</option>
 				<option value="hour">Hour</option>
 				<option value="30min">30 Minutes</option>
@@ -53,28 +50,17 @@
 	{/if}
 
 	<div class="flex items-center gap-2">
-		<label for="chartType" class="text-sm font-medium text-gray-700">Chart type:</label>
-		<select
-			id="chartType"
-			value={chartType}
-			onchange={handleChartTypeChange}
-			class="rounded-md border border-gray-300 px-3 py-1 text-sm focus:ring-2 focus:ring-blue-500 focus:outline-none"
-		>
+		<label for="chartType" class="text-sm font-medium text-slate-700">Chart type</label>
+		<select id="chartType" value={chartType} onchange={handleChartTypeChange} class="control-input">
 			<option value="stacked">Stacked Area</option>
 			<option value="line">Line Chart</option>
 		</select>
 	</div>
 
-	<button
-		type="button"
-		onclick={handleReset}
-		class="rounded-md bg-blue-600 px-4 py-1 text-sm text-white hover:bg-blue-700 focus:ring-2 focus:ring-blue-500 focus:outline-none"
-	>
-		Reset View
-	</button>
+	<button type="button" onclick={handleReset} class="btn-primary"> Reset View </button>
 
-	<div class="flex items-center text-sm text-gray-600">
-		<span class="font-medium">Navigation:</span>
-		<span class="ml-1">Click data points to drill down • {groupBy} view</span>
+	<div class="flex items-center text-sm text-slate-600">
+		<span class="font-medium">Tip:</span>
+		<span class="ml-1">click any chart position to drill down ({groupBy} view)</span>
 	</div>
 </div>

--- a/netflow-webapp/src/lib/components/charts/IPChart.svelte
+++ b/netflow-webapp/src/lib/components/charts/IPChart.svelte
@@ -13,7 +13,12 @@
 		type IpStatsBucket,
 		type IpStatsResponse
 	} from '$lib/types/types';
-	import { generateSlugFromLabel, parseClickedLabel, formatNumber, Y_AXIS_WIDTH } from './chart-utils';
+	import {
+		generateSlugFromLabel,
+		parseClickedLabel,
+		formatNumber,
+		Y_AXIS_WIDTH
+	} from './chart-utils';
 	import { verticalCrosshairPlugin } from './crosshair-plugin';
 	import { crosshairStore } from '$lib/stores/crosshair';
 
@@ -107,7 +112,11 @@
 		return `${year}-${month}-${day} ${hours}:${minutes}`;
 	}
 
-	function formatTickLabel(bucketStart: number, granularity: IpGranularity, _index: number): string {
+	function formatTickLabel(
+		bucketStart: number,
+		granularity: IpGranularity,
+		_index: number
+	): string {
 		const pst = epochToPSTComponents(bucketStart);
 		const day = pst.day.toString().padStart(2, '0');
 		const month = pst.month.toString().padStart(2, '0');
@@ -143,7 +152,11 @@
 		return '';
 	}
 
-	function shouldHighlightTick(bucketStart: number, granularity: IpGranularity, index: number): boolean {
+	function shouldHighlightTick(
+		bucketStart: number,
+		granularity: IpGranularity,
+		index: number
+	): boolean {
 		const pst = epochToPSTComponents(bucketStart);
 		const hours = pst.hours;
 		const minutes = pst.minutes;
@@ -399,15 +412,15 @@
 								maxRotation: 45,
 								minRotation: 45,
 								callback: (_value, idx) =>
-									formatTickLabel(bucketStarts[idx as number] ?? 0, currentGranularity, idx as number)
+									formatTickLabel(
+										bucketStarts[idx as number] ?? 0,
+										currentGranularity,
+										idx as number
+									)
 							},
 							grid: {
 								color: (ctx) =>
-									shouldHighlightTick(
-										bucketStarts[ctx.index] ?? 0,
-										currentGranularity,
-										ctx.index
-									)
+									shouldHighlightTick(bucketStarts[ctx.index] ?? 0, currentGranularity, ctx.index)
 										? 'rgba(0,0,0,0.08)'
 										: 'rgba(0,0,0,0.02)'
 							}
@@ -563,30 +576,23 @@
 	});
 </script>
 
-<div class="rounded-lg border bg-white shadow-sm">
-	<div class="border-b p-4">
-		<h3 class="text-lg font-semibold text-gray-900">Unique IP Counts</h3>
+<div class="surface-card">
+	<div class="surface-card-header">
+		<div>
+			<h3 class="text-lg font-semibold text-slate-900">Unique IP Counts</h3>
+			<p class="text-sm text-slate-600">Source and destination IPv4/IPv6 counts by router</p>
+		</div>
 	</div>
-	<div class="p-4">
-		<div
-			class="h-[320px] min-h-[240px] resize-y overflow-auto rounded-md border border-gray-200 bg-white/60"
-		>
+	<div class="surface-card-body">
+		<div class="chart-frame">
 			{#if loading}
-				<div class="flex h-full items-center justify-center">
-					<div class="text-gray-500">Loading IP data...</div>
-				</div>
+				<div class="status-panel">Loading IP data...</div>
 			{:else if error}
-				<div class="flex h-full items-center justify-center">
-					<div class="text-red-500">{error}</div>
-				</div>
+				<div class="status-panel status-panel-error">{error}</div>
 			{:else if activeMetrics.length === 0}
-				<div class="flex h-full items-center justify-center">
-					<div class="text-gray-500">Select at least one metric to display.</div>
-				</div>
+				<div class="status-panel">Select at least one metric to display.</div>
 			{:else if buckets.length === 0}
-				<div class="flex h-full items-center justify-center">
-					<div class="text-gray-500">No IP data for the selected window.</div>
-				</div>
+				<div class="status-panel">No IP data for the selected window.</div>
 			{:else}
 				<div class="h-full">
 					<canvas bind:this={chartCanvas} aria-label="IP chart"></canvas>

--- a/netflow-webapp/src/lib/components/charts/ProtocolChart.svelte
+++ b/netflow-webapp/src/lib/components/charts/ProtocolChart.svelte
@@ -110,7 +110,11 @@
 			: `${year}-${month}-${day} ${hours}:${minutes}`;
 	}
 
-	function formatTickLabel(bucketStart: number, granularity: IpGranularity, _index: number): string {
+	function formatTickLabel(
+		bucketStart: number,
+		granularity: IpGranularity,
+		_index: number
+	): string {
 		const pst = epochToPSTComponents(bucketStart);
 		const day = pst.day.toString().padStart(2, '0');
 		const month = pst.month.toString().padStart(2, '0');
@@ -146,7 +150,11 @@
 		return '';
 	}
 
-	function shouldHighlightTick(bucketStart: number, granularity: IpGranularity, index: number): boolean {
+	function shouldHighlightTick(
+		bucketStart: number,
+		granularity: IpGranularity,
+		index: number
+	): boolean {
 		const pst = epochToPSTComponents(bucketStart);
 		const hours = pst.hours;
 		const minutes = pst.minutes;
@@ -371,15 +379,15 @@
 								maxRotation: 45,
 								minRotation: 45,
 								callback: (_value, idx) =>
-									formatTickLabel(bucketStarts[idx as number] ?? 0, currentGranularity, idx as number)
+									formatTickLabel(
+										bucketStarts[idx as number] ?? 0,
+										currentGranularity,
+										idx as number
+									)
 							},
 							grid: {
 								color: (ctx) =>
-									shouldHighlightTick(
-										bucketStarts[ctx.index] ?? 0,
-										currentGranularity,
-										ctx.index
-									)
+									shouldHighlightTick(bucketStarts[ctx.index] ?? 0, currentGranularity, ctx.index)
 										? 'rgba(0,0,0,0.08)'
 										: 'rgba(0,0,0,0.02)'
 							}
@@ -519,30 +527,23 @@
 	});
 </script>
 
-<div class="rounded-lg border bg-white shadow-sm">
-	<div class="border-b p-4">
-		<h3 class="text-lg font-semibold text-gray-900">Unique Protocol Counts</h3>
+<div class="surface-card">
+	<div class="surface-card-header">
+		<div>
+			<h3 class="text-lg font-semibold text-slate-900">Unique Protocol Counts</h3>
+			<p class="text-sm text-slate-600">Distinct protocol trends split by IP family</p>
+		</div>
 	</div>
-	<div class="p-4">
-		<div
-			class="h-[320px] min-h-[240px] resize-y overflow-auto rounded-md border border-gray-200 bg-white/60"
-		>
+	<div class="surface-card-body">
+		<div class="chart-frame">
 			{#if loading}
-				<div class="flex h-full items-center justify-center">
-					<div class="text-gray-500">Loading protocol data...</div>
-				</div>
+				<div class="status-panel">Loading protocol data...</div>
 			{:else if error}
-				<div class="flex h-full items-center justify-center">
-					<div class="text-red-500">{error}</div>
-				</div>
+				<div class="status-panel status-panel-error">{error}</div>
 			{:else if activeMetrics.length === 0}
-				<div class="flex h-full items-center justify-center">
-					<div class="text-gray-500">Select at least one metric to display.</div>
-				</div>
+				<div class="status-panel">Select at least one metric to display.</div>
 			{:else if buckets.length === 0}
-				<div class="flex h-full items-center justify-center">
-					<div class="text-gray-500">No protocol data for the selected window.</div>
-				</div>
+				<div class="status-panel">No protocol data for the selected window.</div>
 			{:else}
 				<div class="h-full">
 					<canvas bind:this={chartCanvas} aria-label="Protocol chart"></canvas>

--- a/netflow-webapp/src/lib/components/charts/SingularitiesList.svelte
+++ b/netflow-webapp/src/lib/components/charts/SingularitiesList.svelte
@@ -14,7 +14,9 @@
 
 {#if data}
 	<div class="w-full space-y-4">
-		<div class="mb-2 text-sm text-gray-600">
+		<div
+			class="mb-2 rounded-lg border border-slate-200/70 bg-slate-50/65 p-3 text-sm text-slate-600"
+		>
 			<p>
 				Data Source: {data.metadata.dataSource} | Address Type: {data.metadata.addressType}
 			</p>
@@ -22,12 +24,12 @@
 		</div>
 
 		{#if topSingularities.length > 0}
-			<div class="rounded-lg border bg-green-50 p-4">
-				<h4 class="mb-2 font-semibold">Top Singularities (Most Anomalous)</h4>
+			<div class="rounded-lg border border-emerald-200 bg-emerald-50/65 p-4">
+				<h4 class="mb-2 font-semibold text-emerald-900">Top Singularities (Most Anomalous)</h4>
 				<div class="overflow-x-auto">
 					<table class="w-full text-sm">
 						<thead>
-							<tr class="border-b border-green-200">
+							<tr class="border-b border-emerald-200">
 								<th class="px-2 py-1 text-left">Rank</th>
 								<th class="px-2 py-1 text-left">IP Address</th>
 								<th class="px-2 py-1 text-left">α (Alpha)</th>
@@ -38,7 +40,7 @@
 						</thead>
 						<tbody>
 							{#each topSingularities as singularity (singularity.rank)}
-								<tr class="border-b border-green-100">
+								<tr class="border-b border-emerald-100">
 									<td class="px-2 py-1">{singularity.rank}</td>
 									<td class="px-2 py-1 font-mono">{singularity.address}</td>
 									<td class="px-2 py-1">{singularity.alpha.toFixed(4)}</td>
@@ -54,12 +56,12 @@
 		{/if}
 
 		{#if bottomSingularities.length > 0}
-			<div class="rounded-lg border bg-red-50 p-4">
-				<h4 class="mb-2 font-semibold">Bottom Singularities (Least Anomalous)</h4>
+			<div class="rounded-lg border border-rose-200 bg-rose-50/70 p-4">
+				<h4 class="mb-2 font-semibold text-rose-900">Bottom Singularities (Least Anomalous)</h4>
 				<div class="overflow-x-auto">
 					<table class="w-full text-sm">
 						<thead>
-							<tr class="border-b border-red-200">
+							<tr class="border-b border-rose-200">
 								<th class="px-2 py-1 text-left">Rank</th>
 								<th class="px-2 py-1 text-left">IP Address</th>
 								<th class="px-2 py-1 text-left">α (Alpha)</th>
@@ -70,7 +72,7 @@
 						</thead>
 						<tbody>
 							{#each bottomSingularities as singularity (singularity.rank)}
-								<tr class="border-b border-red-100">
+								<tr class="border-b border-rose-100">
 									<td class="px-2 py-1">{singularity.rank}</td>
 									<td class="px-2 py-1 font-mono">{singularity.address}</td>
 									<td class="px-2 py-1">{singularity.alpha.toFixed(4)}</td>
@@ -86,15 +88,15 @@
 		{/if}
 
 		{#if topSingularities.length === 0 && bottomSingularities.length === 0}
-			<div class="rounded-lg border bg-gray-50 p-4">
-				<p class="text-gray-600">No singularities data available.</p>
+			<div class="rounded-lg border border-slate-200 bg-slate-50 p-4">
+				<p class="text-slate-600">No singularities data available.</p>
 			</div>
 		{/if}
 	</div>
 {:else}
 	<div class="w-full">
-		<div class="rounded-lg border bg-gray-50 p-4">
-			<p class="text-gray-600">Loading singularities data...</p>
+		<div class="rounded-lg border border-slate-200 bg-slate-50 p-4">
+			<p class="text-slate-600">Loading singularities data...</p>
 		</div>
 	</div>
 {/if}

--- a/netflow-webapp/src/lib/components/charts/SpectrumChart.svelte
+++ b/netflow-webapp/src/lib/components/charts/SpectrumChart.svelte
@@ -21,14 +21,6 @@
 
 	// Watch for data changes and create/update chart
 	$effect(() => {
-		console.log('SpectrumChart effect triggered', {
-			hasCanvas: !!chartCanvas,
-			hasData: !!data,
-			hasSpectrum: !!data?.spectrum,
-			dataLength: data?.spectrum?.length || 0,
-			router: data?.router
-		});
-
 		if (chartCanvas && data?.spectrum?.length > 0) {
 			if (chart) {
 				chart.destroy();
@@ -50,12 +42,12 @@
 				{
 					label: 'f(alpha)',
 					data: points.map((p) => ({ x: p.alpha, y: p.f })),
-					borderColor: 'rgb(147, 51, 234)',
-					backgroundColor: 'rgba(147, 51, 234, 0.1)',
+					borderColor: 'rgb(14, 116, 144)',
+					backgroundColor: 'rgba(14, 116, 144, 0.1)',
 					borderWidth: 2,
 					pointRadius: 3,
 					pointHoverRadius: 5,
-					pointBackgroundColor: 'rgb(147, 51, 234)',
+					pointBackgroundColor: 'rgb(14, 116, 144)',
 					pointBorderColor: 'white',
 					pointBorderWidth: 1,
 					fill: false,
@@ -151,19 +143,18 @@
 </script>
 
 <div class="w-full">
-	<div class="mb-2 text-sm text-gray-600">
+	<div class="mb-2 rounded-lg border border-slate-200/70 bg-slate-50/65 p-3 text-sm text-slate-600">
 		<p>
 			Data Source: {data.metadata.dataSource} | alpha Range: [{data.metadata.alphaRange.min.toFixed(
 				3
 			)}, {data.metadata.alphaRange.max.toFixed(3)}]
 		</p>
 		{#if data.metadata.uniqueIPCount && data.metadata.uniqueIPCount > 0}
-			<p class="text-xs font-medium text-green-600">
-				✓ Real NetFlow Data Analysis - {data.metadata.uniqueIPCount.toLocaleString()} unique IP addresses
-				analyzed
+			<p class="text-xs font-medium text-emerald-700">
+				Real NetFlow data analysis ({data.metadata.uniqueIPCount.toLocaleString()} unique IP addresses)
 			</p>
 		{:else if data.metadata.uniqueIPCount !== -1}
-			<p class="text-xs text-amber-600">⚠ Using test data from MAAD sample set</p>
+			<p class="text-xs text-amber-700">Using test data from MAAD sample set</p>
 		{/if}
 	</div>
 	<div class="relative h-96 w-full">

--- a/netflow-webapp/src/lib/components/charts/SpectrumStatsChart.svelte
+++ b/netflow-webapp/src/lib/components/charts/SpectrumStatsChart.svelte
@@ -158,14 +158,12 @@
 		return index === 0;
 	}
 
-	// Color gradient function based on f value
-	// Purple (low f) -> Blue -> Cyan -> Green -> Yellow (high f)
+	// Color gradient based on f value: navy (low f) to amber (high f)
 	function getColorForF(f: number, minF: number, maxF: number): string {
-		if (maxF === minF) return 'hsl(180, 70%, 50%)';
+		if (maxF === minF) return 'hsl(195, 70%, 45%)';
 		const normalized = (f - minF) / (maxF - minF);
-		// HSL: hue 270=purple, 180=cyan, 120=green, 60=yellow
-		const hue = 270 - normalized * 210; // 270 (purple) to 60 (yellow)
-		return `hsl(${hue}, 70%, 50%)`;
+		const hue = 210 - normalized * 170;
+		return `hsl(${hue}, 76%, 46%)`;
 	}
 
 	function destroyChart() {
@@ -617,16 +615,20 @@
 	});
 </script>
 
-<div class="rounded-lg border bg-white shadow-sm">
-	<div class="border-b p-4">
+<div class="surface-card">
+	<div class="surface-card-header">
 		<div class="flex items-center justify-between">
-			<h3 class="text-lg font-semibold text-gray-900">Spectrum</h3>
+			<div>
+				<h3 class="text-lg font-semibold text-slate-900">Spectrum</h3>
+				<p class="text-sm text-slate-600">Time-indexed multifractal spectrum density</p>
+			</div>
 			<div class="flex items-center gap-2">
 				<button
 					type="button"
-					class="rounded px-3 py-1 text-sm font-medium transition-colors {addressType === 'sa'
-						? 'bg-blue-600 text-white'
-						: 'bg-gray-200 text-gray-700 hover:bg-gray-300'}"
+					class="rounded-md border px-3 py-1 text-sm font-medium transition-colors {addressType ===
+					'sa'
+						? 'border-cyan-700 bg-cyan-700 text-white'
+						: 'border-slate-300 bg-slate-100 text-slate-700 hover:bg-slate-200'}"
 					onclick={() => {
 						if (addressType !== 'sa') {
 							addressType = 'sa';
@@ -638,9 +640,10 @@
 				</button>
 				<button
 					type="button"
-					class="rounded px-3 py-1 text-sm font-medium transition-colors {addressType === 'da'
-						? 'bg-blue-600 text-white'
-						: 'bg-gray-200 text-gray-700 hover:bg-gray-300'}"
+					class="rounded-md border px-3 py-1 text-sm font-medium transition-colors {addressType ===
+					'da'
+						? 'border-cyan-700 bg-cyan-700 text-white'
+						: 'border-slate-300 bg-slate-100 text-slate-700 hover:bg-slate-200'}"
 					onclick={() => {
 						if (addressType !== 'da') {
 							addressType = 'da';
@@ -653,22 +656,14 @@
 			</div>
 		</div>
 	</div>
-	<div class="p-4">
-		<div
-			class="h-[400px] min-h-[300px] resize-y overflow-auto rounded-md border border-gray-200 bg-white/60"
-		>
+	<div class="surface-card-body">
+		<div class="chart-frame chart-frame-tall">
 			{#if loading}
-				<div class="flex h-full items-center justify-center">
-					<div class="text-gray-500">Loading spectrum data...</div>
-				</div>
+				<div class="status-panel">Loading spectrum data...</div>
 			{:else if error}
-				<div class="flex h-full items-center justify-center">
-					<div class="text-red-500">{error}</div>
-				</div>
+				<div class="status-panel status-panel-error">{error}</div>
 			{:else if buckets.length === 0}
-				<div class="flex h-full items-center justify-center">
-					<div class="text-gray-500">No spectrum data for the selected window.</div>
-				</div>
+				<div class="status-panel">No spectrum data for the selected window.</div>
 			{:else}
 				<div class="h-full">
 					<canvas bind:this={chartCanvas} aria-label="Spectrum chart"></canvas>

--- a/netflow-webapp/src/lib/components/charts/StructureFunctionChart.svelte
+++ b/netflow-webapp/src/lib/components/charts/StructureFunctionChart.svelte
@@ -10,14 +10,12 @@
 	}
 
 	interface StructureFunctionData {
-		slug: string;
 		router: string;
 		filename: string;
 		structureFunction: StructureFunctionPoint[];
 		metadata: {
 			dataSource: string;
 			uniqueIPCount?: number;
-			pointCount: number;
 			qRange: { min: number; max: number };
 		};
 	}
@@ -39,14 +37,6 @@
 
 	// Watch for data changes and create/update chart
 	$effect(() => {
-		console.log('StructureFunctionChart effect triggered', {
-			hasCanvas: !!chartCanvas,
-			hasData: !!data,
-			hasStructureFunction: !!data?.structureFunction,
-			dataLength: data?.structureFunction?.length || 0,
-			router: data?.router
-		});
-
 		if (chartCanvas && data?.structureFunction?.length > 0) {
 			if (chart) {
 				chart.destroy();
@@ -202,23 +192,17 @@
 </script>
 
 <div class="w-full">
-	<div class="mb-2 text-sm text-gray-600">
+	<div class="mb-2 rounded-lg border border-slate-200/70 bg-slate-50/65 p-3 text-sm text-slate-600">
 		<p>
-			Data Source: {data.metadata.dataSource} | q Range: [{data.metadata.qRange.min.toFixed(1)}, {data.metadata.qRange.max.toFixed(
-				1
-			)}]
+			Data Source: {data.metadata.dataSource} | q Range: [{data.metadata.qRange.min.toFixed(1)},
+			{data.metadata.qRange.max.toFixed(1)}]
 		</p>
 		{#if data.metadata.uniqueIPCount && data.metadata.uniqueIPCount > 0}
-			<p class="text-xs font-medium text-green-600">
-				✓ Real NetFlow Data Analysis - {data.metadata.uniqueIPCount.toLocaleString()} unique IP addresses
-				analyzed
+			<p class="text-xs font-medium text-emerald-700">
+				Real NetFlow data analysis ({data.metadata.uniqueIPCount.toLocaleString()} unique IP addresses)
 			</p>
-			<!-- {:else if data.metadata.uniqueIPCount === -1}
-			<p class="text-xs font-medium text-green-600">
-				✓ Real NetFlow Data Analysis - IPv4 source addresses processed directly
-			</p> -->
 		{:else if data.metadata.uniqueIPCount !== -1}
-			<p class="text-xs text-amber-600">⚠ Using test data from MAAD sample set</p>
+			<p class="text-xs text-amber-700">Using test data from MAAD sample set</p>
 		{/if}
 	</div>
 	<div class="relative h-96 w-full">

--- a/netflow-webapp/src/lib/components/filters/DateRangeFilter.svelte
+++ b/netflow-webapp/src/lib/components/filters/DateRangeFilter.svelte
@@ -19,26 +19,33 @@
 	}
 </script>
 
-<div class="date-range-filter flex flex-wrap items-center gap-4">
-	<div class="flex items-center gap-2">
-		<label for="startDate" class="text-sm font-medium text-gray-700">Start Date:</label>
-		<input
-			id="startDate"
-			type="date"
-			value={startDate}
-			onchange={handleStartDateChange}
-			class="rounded-md border border-gray-300 px-3 py-1 text-sm focus:ring-2 focus:ring-blue-500 focus:outline-none"
-		/>
-	</div>
+<div class="date-range-filter">
+	<h3 class="mb-3 text-sm font-semibold tracking-[0.08em] text-slate-700 uppercase">Date Window</h3>
+	<div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
+		<div class="flex flex-col gap-1.5">
+			<label for="startDate" class="text-xs font-medium tracking-[0.06em] text-slate-600 uppercase"
+				>Start Date</label
+			>
+			<input
+				id="startDate"
+				type="date"
+				value={startDate}
+				onchange={handleStartDateChange}
+				class="control-input"
+			/>
+		</div>
 
-	<div class="flex items-center gap-2">
-		<label for="endDate" class="text-sm font-medium text-gray-700">End Date:</label>
-		<input
-			id="endDate"
-			type="date"
-			value={endDate}
-			onchange={handleEndDateChange}
-			class="rounded-md border border-gray-300 px-3 py-1 text-sm focus:ring-2 focus:ring-blue-500 focus:outline-none"
-		/>
+		<div class="flex flex-col gap-1.5">
+			<label for="endDate" class="text-xs font-medium tracking-[0.06em] text-slate-600 uppercase"
+				>End Date</label
+			>
+			<input
+				id="endDate"
+				type="date"
+				value={endDate}
+				onchange={handleEndDateChange}
+				class="control-input"
+			/>
+		</div>
 	</div>
 </div>

--- a/netflow-webapp/src/lib/components/filters/MetricSelector.svelte
+++ b/netflow-webapp/src/lib/components/filters/MetricSelector.svelte
@@ -37,58 +37,45 @@
 		const newDataOptions = dataOptions.map((option) => ({ ...option, checked: false }));
 		onDataOptionsChange?.(newDataOptions);
 	}
+
+	const selectedCount = $derived(dataOptions.filter((option) => option.checked).length);
 </script>
 
 <div class="metric-selector">
+	<div class="mb-3 flex flex-wrap items-center justify-between gap-2">
+		<h4 class="text-sm font-semibold tracking-[0.08em] text-slate-700 uppercase">
+			Quick Select ({selectedCount}/{dataOptions.length})
+		</h4>
+		<div class="flex flex-wrap gap-2">
+			<button type="button" onclick={handleSelectAll} class="btn-muted">All</button>
+			<button type="button" onclick={handleSelectNone} class="btn-muted">None</button>
+		</div>
+	</div>
+
 	<div class="mb-4 flex flex-wrap gap-2">
-		<span class="text-sm font-medium text-gray-700">Quick Select:</span>
-		<button
-			type="button"
-			onclick={() => handleQuickSelect('flows')}
-			class="rounded-md bg-green-100 px-3 py-1 text-xs text-green-800 hover:bg-green-200 focus:ring-2 focus:ring-green-500 focus:outline-none"
-		>
-			All Flows
+		<button type="button" onclick={() => handleQuickSelect('flows')} class="btn-muted">
+			Flows
 		</button>
-		<button
-			type="button"
-			onclick={() => handleQuickSelect('packets')}
-			class="rounded-md bg-blue-100 px-3 py-1 text-xs text-blue-800 hover:bg-blue-200 focus:ring-2 focus:ring-blue-500 focus:outline-none"
-		>
-			All Packets
+		<button type="button" onclick={() => handleQuickSelect('packets')} class="btn-muted">
+			Packets
 		</button>
-		<button
-			type="button"
-			onclick={() => handleQuickSelect('bytes')}
-			class="rounded-md bg-purple-100 px-3 py-1 text-xs text-purple-800 hover:bg-purple-200 focus:ring-2 focus:ring-purple-500 focus:outline-none"
-		>
-			All Bytes
-		</button>
-		<button
-			type="button"
-			onclick={handleSelectAll}
-			class="rounded-md bg-gray-100 px-3 py-1 text-xs text-gray-800 hover:bg-gray-200 focus:ring-2 focus:ring-gray-500 focus:outline-none"
-		>
-			Select All
-		</button>
-		<button
-			type="button"
-			onclick={handleSelectNone}
-			class="rounded-md bg-gray-100 px-3 py-1 text-xs text-gray-800 hover:bg-gray-200 focus:ring-2 focus:ring-gray-500 focus:outline-none"
-		>
-			Select None
+		<button type="button" onclick={() => handleQuickSelect('bytes')} class="btn-muted">
+			Bytes
 		</button>
 	</div>
 
 	<div class="grid grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-5">
 		{#each dataOptions as option, index (index)}
-			<label class="flex cursor-pointer items-center gap-2 rounded-md p-2 hover:bg-gray-50">
+			<label
+				class="flex cursor-pointer items-center gap-2 rounded-md border border-slate-200/70 bg-white px-2 py-2 hover:bg-slate-50"
+			>
 				<input
 					type="checkbox"
 					checked={option.checked}
 					onchange={() => handleMetricToggle(index)}
-					class="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+					class="h-4 w-4 rounded border-slate-300 text-cyan-700 focus:ring-cyan-700"
 				/>
-				<span class="text-sm text-gray-700 select-none">{option.label}</span>
+				<span class="text-sm text-slate-700 select-none">{option.label}</span>
 			</label>
 		{/each}
 	</div>

--- a/netflow-webapp/src/lib/components/filters/PrimaryFilters.svelte
+++ b/netflow-webapp/src/lib/components/filters/PrimaryFilters.svelte
@@ -81,15 +81,28 @@
 			: [...current, metric];
 		dispatch('protocolMetricsChange', { metrics });
 	}
+
+	const selectedRouterCount = $derived(Object.values(props.routers).filter(Boolean).length);
+	const selectedNetflowMetricCount = $derived(
+		props.dataOptions.filter((option: DataOption) => option.checked).length
+	);
+	const selectedIpMetricCount = $derived(props.ipMetrics.length);
+	const selectedProtocolMetricCount = $derived(props.protocolMetrics.length);
 </script>
 
-<div class="space-y-4 rounded-lg border bg-white p-4 shadow-sm">
-	<div class="flex items-center justify-between">
-		<h2 class="text-lg font-semibold text-gray-900">Filters</h2>
-		<label class="text-sm text-gray-600">
+<div class="surface-card">
+	<div class="surface-card-header">
+		<div>
+			<h2 class="text-lg font-semibold text-slate-900">Filters</h2>
+			<p class="text-xs text-slate-600">
+				{selectedRouterCount} routers, {selectedNetflowMetricCount} NetFlow metrics, {selectedIpMetricCount}
+				IP metrics, {selectedProtocolMetricCount} protocol metrics selected
+			</p>
+		</div>
+		<label class="text-sm font-medium text-slate-700">
 			Granularity
 			<select
-				class="ml-2 rounded border border-gray-300 bg-white px-2 py-1 text-sm text-gray-700 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+				class="control-input ml-2"
 				value={props.groupBy}
 				onchange={handleGroupBySelect}
 				aria-label="Select aggregation granularity"
@@ -101,53 +114,66 @@
 		</label>
 	</div>
 
-	<DateRangeFilter
-		startDate={props.startDate}
-		endDate={props.endDate}
-		onStartDateChange={handleStartDateChange}
-		onEndDateChange={handleEndDateChange}
-	/>
-
-	<RouterFilter routers={props.routers} onRouterChange={handleRoutersChange} />
-
-	<div class="space-y-2">
-		<h3 class="text-base font-semibold text-gray-900">NetFlow Metrics</h3>
-		<MetricSelector dataOptions={props.dataOptions} onDataOptionsChange={handleDataOptionsChange} />
-	</div>
-
-	<div class="space-y-2">
-		<h3 class="text-base font-semibold text-gray-900">IP Metrics</h3>
-		<div class="flex flex-wrap items-center gap-4">
-			{#each IP_METRIC_OPTIONS as option (option.key)}
-				<label class="flex cursor-pointer items-center gap-2">
-					<input
-						type="checkbox"
-						checked={props.ipMetrics.includes(option.key)}
-						onchange={() => handleIpMetricToggle(option.key)}
-						class="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
-					/>
-					<span class="text-sm text-gray-700">{option.label}</span>
-				</label>
-			{/each}
+	<div class="surface-card-body space-y-4">
+		<div class="rounded-lg border border-slate-200/70 bg-slate-50/60 p-3">
+			<DateRangeFilter
+				startDate={props.startDate}
+				endDate={props.endDate}
+				onStartDateChange={handleStartDateChange}
+				onEndDateChange={handleEndDateChange}
+			/>
 		</div>
-	</div>
 
-	<div class="space-y-2">
-		<h3 class="text-base font-semibold text-gray-900">Protocol Metrics</h3>
-		<div class="flex flex-wrap items-center gap-4">
-			{#each ['uniqueProtocolsIpv4', 'uniqueProtocolsIpv6'] as const as key (key)}
-				<label class="flex cursor-pointer items-center gap-2">
-					<input
-						type="checkbox"
-						checked={props.protocolMetrics.includes(key)}
-						onchange={() => handleProtocolMetricToggle(key)}
-						class="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
-					/>
-					<span class="text-sm text-gray-700">
-						{key === 'uniqueProtocolsIpv4' ? 'Unique Protocols IPv4' : 'Unique Protocols IPv6'}
-					</span>
-				</label>
-			{/each}
+		<div class="rounded-lg border border-slate-200/70 bg-slate-50/60 p-3">
+			<RouterFilter routers={props.routers} onRouterChange={handleRoutersChange} />
+		</div>
+
+		<div class="space-y-2">
+			<h3 class="text-base font-semibold text-slate-900">NetFlow Metrics</h3>
+			<MetricSelector
+				dataOptions={props.dataOptions}
+				onDataOptionsChange={handleDataOptionsChange}
+			/>
+		</div>
+
+		<div class="space-y-2">
+			<h3 class="text-base font-semibold text-slate-900">IP Metrics</h3>
+			<div class="flex flex-wrap items-center gap-3">
+				{#each IP_METRIC_OPTIONS as option (option.key)}
+					<label
+						class="flex cursor-pointer items-center gap-2 rounded-lg border border-slate-200/80 bg-white px-3 py-2"
+					>
+						<input
+							type="checkbox"
+							checked={props.ipMetrics.includes(option.key)}
+							onchange={() => handleIpMetricToggle(option.key)}
+							class="h-4 w-4 rounded border-slate-300 text-cyan-700 focus:ring-cyan-700"
+						/>
+						<span class="text-sm text-slate-700">{option.label}</span>
+					</label>
+				{/each}
+			</div>
+		</div>
+
+		<div class="space-y-2">
+			<h3 class="text-base font-semibold text-slate-900">Protocol Metrics</h3>
+			<div class="flex flex-wrap items-center gap-3">
+				{#each ['uniqueProtocolsIpv4', 'uniqueProtocolsIpv6'] as const as key (key)}
+					<label
+						class="flex cursor-pointer items-center gap-2 rounded-lg border border-slate-200/80 bg-white px-3 py-2"
+					>
+						<input
+							type="checkbox"
+							checked={props.protocolMetrics.includes(key)}
+							onchange={() => handleProtocolMetricToggle(key)}
+							class="h-4 w-4 rounded border-slate-300 text-cyan-700 focus:ring-cyan-700"
+						/>
+						<span class="text-sm text-slate-700">
+							{key === 'uniqueProtocolsIpv4' ? 'Unique Protocols IPv4' : 'Unique Protocols IPv6'}
+						</span>
+					</label>
+				{/each}
+			</div>
 		</div>
 	</div>
 </div>

--- a/netflow-webapp/src/lib/components/filters/RouterFilter.svelte
+++ b/netflow-webapp/src/lib/components/filters/RouterFilter.svelte
@@ -15,20 +15,45 @@
 		};
 		onRouterChange?.(newRouters);
 	}
+
+	function setAllRouters(enabled: boolean) {
+		const newRouters = Object.fromEntries(
+			Object.keys(routers).map((routerName) => [routerName, enabled])
+		);
+		onRouterChange?.(newRouters);
+	}
+
+	const selectedCount = $derived(Object.values(routers).filter(Boolean).length);
 </script>
 
-<div class="router-filter flex flex-wrap items-center gap-4">
-	<span class="text-sm font-medium text-gray-700">Routers:</span>
+<div class="router-filter">
+	<div class="mb-3 flex flex-wrap items-center justify-between gap-2">
+		<h3 class="text-sm font-semibold tracking-[0.08em] text-slate-700 uppercase">
+			Routers ({selectedCount}/{Object.keys(routers).length})
+		</h3>
+		<div class="flex items-center gap-2">
+			<button type="button" class="btn-muted" onclick={() => setAllRouters(true)}>All</button>
+			<button type="button" class="btn-muted" onclick={() => setAllRouters(false)}>None</button>
+		</div>
+	</div>
 
-	{#each Object.keys(routers) as routerName (routerName)}
-		<label class="flex cursor-pointer items-center gap-2">
-			<input
-				type="checkbox"
-				checked={routers[routerName]}
-				onchange={() => handleRouterToggle(routerName)}
-				class="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
-			/>
-			<span class="text-sm text-gray-700">{routerName}</span>
-		</label>
-	{/each}
+	{#if Object.keys(routers).length === 0}
+		<p class="text-sm text-slate-500">Loading router list...</p>
+	{:else}
+		<div class="flex flex-wrap items-center gap-2">
+			{#each Object.keys(routers) as routerName (routerName)}
+				<label
+					class="flex cursor-pointer items-center gap-2 rounded-lg border border-slate-200/80 bg-white px-3 py-2"
+				>
+					<input
+						type="checkbox"
+						checked={routers[routerName]}
+						onchange={() => handleRouterToggle(routerName)}
+						class="h-4 w-4 rounded border-slate-300 text-cyan-700 focus:ring-cyan-700"
+					/>
+					<span class="text-sm text-slate-700">{routerName}</span>
+				</label>
+			{/each}
+		</div>
+	{/if}
 </div>

--- a/netflow-webapp/src/lib/components/netflow/NetflowDashboard.svelte
+++ b/netflow-webapp/src/lib/components/netflow/NetflowDashboard.svelte
@@ -162,12 +162,15 @@
 	});
 </script>
 
-<div class="rounded-lg border bg-white shadow-sm">
-	<div class="border-b p-4">
-		<h2 class="text-lg font-semibold text-gray-900">NetFlow Visualization</h2>
+<div class="surface-card">
+	<div class="surface-card-header">
+		<div>
+			<h2 class="text-lg font-semibold text-slate-900">NetFlow Volume</h2>
+			<p class="text-sm text-slate-600">Stacked or line comparison across selected metrics</p>
+		</div>
 	</div>
 
-	<div class="space-y-4 p-4">
+	<div class="surface-card-body space-y-4">
 		<ChartControls
 			groupBy={props.groupBy}
 			{chartType}
@@ -177,21 +180,13 @@
 			showGroupBy={false}
 		/>
 
-		<div
-			class="h-[320px] min-h-[240px] resize-y overflow-auto rounded-md border border-gray-200 bg-white/60"
-		>
+		<div class="chart-frame">
 			{#if loading}
-				<div class="flex h-full items-center justify-center">
-					<div class="text-gray-500">Loading data...</div>
-				</div>
+				<div class="status-panel">Loading NetFlow data...</div>
 			{:else if error}
-				<div class="flex h-full items-center justify-center">
-					<div class="text-red-500">{error}</div>
-				</div>
+				<div class="status-panel status-panel-error">{error}</div>
 			{:else if results.length === 0}
-				<div class="flex h-full items-center justify-center">
-					<div class="text-gray-500">No data available for the selected filters</div>
-				</div>
+				<div class="status-panel">No NetFlow data available for the selected filters.</div>
 			{:else}
 				<ChartContainer
 					{results}

--- a/netflow-webapp/src/routes/+error.svelte
+++ b/netflow-webapp/src/routes/+error.svelte
@@ -15,46 +15,33 @@
 	}
 </script>
 
-<div class="container mx-auto p-6">
-	<div class="mx-auto max-w-2xl text-center">
-		<div class="mb-6">
-			<h1 class="mb-2 text-4xl font-bold text-gray-900">{page.status}</h1>
-			<h2 class="mb-4 text-2xl font-semibold text-gray-700">{getErrorTitle(page.status)}</h2>
-		</div>
+<div class="app-content-shell">
+	<div class="surface-card mx-auto max-w-2xl">
+		<div class="surface-card-body text-center">
+			<p class="text-sm font-semibold tracking-[0.12em] text-cyan-800/75 uppercase">
+				Request Failed
+			</p>
+			<h1 class="mt-1 text-5xl font-bold text-slate-900">{page.status}</h1>
+			<h2 class="mt-1 text-2xl font-semibold text-slate-700">{getErrorTitle(page.status)}</h2>
 
-		{#if page.error?.message}
-			<div class="mb-6 rounded-lg border border-red-200 bg-red-50 p-6">
-				<div class="text-sm text-red-900">
+			{#if page.error?.message}
+				<div class="mt-5 rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-900">
 					{page.error.message}
 				</div>
-			</div>
-		{/if}
+			{/if}
 
-		<div class="space-y-3">
-			<div class="flex justify-center space-x-4">
-				<button
-					onclick={() => window.history.back()}
-					class="rounded bg-gray-600 px-4 py-2 text-white hover:bg-gray-700 focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 focus:outline-none"
-				>
-					Go Back
-				</button>
-				<a
-					href="/"
-					class="rounded bg-blue-600 px-4 py-2 text-white hover:bg-blue-700 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:outline-none"
-				>
-					Home
-				</a>
+			<div class="mt-6 flex flex-wrap justify-center gap-3">
+				<button onclick={() => window.history.back()} class="btn-muted">Go Back</button>
+				<a href="/" class="btn-primary">Home</a>
 			</div>
 
 			{#if page.status === 404}
-				<div class="mt-4 text-sm text-gray-600">
-					<p>
-						If you're looking for a specific NetFlow file, try using the timestamp search on the <a
-							href="/api/netflow/files"
-							class="text-blue-600 hover:underline">Files page</a
-						>.
-					</p>
-				</div>
+				<p class="mt-5 text-sm text-slate-600">
+					Looking for a specific NetFlow file? Use timestamp search on the
+					<a href="/api/netflow/files" class="font-semibold text-cyan-800 hover:underline">
+						Files page
+					</a>.
+				</p>
 			{/if}
 		</div>
 	</div>

--- a/netflow-webapp/src/routes/+layout.svelte
+++ b/netflow-webapp/src/routes/+layout.svelte
@@ -1,21 +1,30 @@
 <script lang="ts">
+	import { page } from '$app/state';
 	import '../app.css';
 
 	let { children } = $props();
 </script>
 
-<header class="border-b bg-white shadow-sm">
-	<div class="mx-auto max-w-[90vw] px-4 sm:px-2 lg:px-4">
-		<div class="flex items-center justify-between py-6">
+<header class="sticky top-0 z-20 border-b border-slate-200/70 bg-white/85 backdrop-blur">
+	<div class="mx-auto w-full max-w-7xl px-4 py-4 sm:px-6 lg:px-8">
+		<div class="flex flex-wrap items-center justify-between gap-4">
 			<div>
-				<h1 class="text-3xl font-bold text-gray-900 hover:underline">
+				<h1 class="text-2xl font-bold text-slate-900 sm:text-3xl">
 					<a href="/">NetFlow Analysis</a>
 				</h1>
-				<p class="mt-1 text-sm text-gray-600">An Oregon Network Research Group Project</p>
+				<p class="mt-1 text-sm text-slate-600">Oregon Network Research Group</p>
 			</div>
-			<div class="flex items-center gap-4">
-				<a href="/" class="text-gray-500 hover:text-gray-900">Home</a>
-				<a href="/api/netflow/files" class="text-gray-500 hover:text-gray-900">Files</a>
+			<div
+				class="flex items-center gap-2 rounded-full border border-slate-200/70 bg-slate-50/85 p-1"
+			>
+				<a href="/" class={`nav-link ${page.url.pathname === '/' ? 'nav-link-active' : ''}`}>Home</a
+				>
+				<a
+					href="/api/netflow/files"
+					class={`nav-link ${page.url.pathname.startsWith('/api/netflow/files') ? 'nav-link-active' : ''}`}
+				>
+					Files
+				</a>
 			</div>
 		</div>
 	</div>

--- a/netflow-webapp/src/routes/+page.svelte
+++ b/netflow-webapp/src/routes/+page.svelte
@@ -128,8 +128,20 @@
 	<meta name="description" content="NetFlow analysis and visualization tool" />
 </svelte:head>
 
-<div class="min-h-screen bg-gray-100">
-	<main class="mx-auto flex max-w-[90vw] flex-col gap-2 px-4 py-8 sm:px-2 lg:px-4">
+<div class="min-h-screen">
+	<main class="app-content-shell flex flex-col gap-4">
+		<section class="surface-card">
+			<div class="surface-card-body">
+				<p class="text-sm font-semibold tracking-[0.12em] text-cyan-800/75 uppercase">Dashboard</p>
+				<h2 class="mt-1 text-2xl font-bold text-slate-900">Traffic Trends and MAAD Signals</h2>
+				<p class="mt-2 max-w-4xl text-sm text-slate-600">
+					Use the filters to compare routers and drill from daily rollups down to file-level
+					windows. Charts stay synchronized so hover and drill-down behavior is consistent across
+					metrics.
+				</p>
+			</div>
+		</section>
+
 		<PrimaryFilters
 			{startDate}
 			{endDate}

--- a/netflow-webapp/src/routes/api/netflow/files/+page.svelte
+++ b/netflow-webapp/src/routes/api/netflow/files/+page.svelte
@@ -30,38 +30,42 @@
 	}
 </script>
 
-<div class="mx-auto max-w-[90vw] px-4 py-8 sm:px-2 lg:px-4">
-	<h1 class="mb-4 text-2xl text-black">NetFlow Files</h1>
-
-	<div class="mb-6 rounded-lg border bg-blue-50 p-4">
-		<h2 class="mb-3 text-lg font-semibold">Navigate to File by Timestamp</h2>
-		<div class="flex items-center space-x-3">
-			<div class="flex-1">
-				<label for="timestamp" class="mb-1 block text-sm font-medium text-gray-700">
-					File Timestamp (YYYYMMDDHHmm)
-				</label>
-				<input
-					id="timestamp"
-					type="text"
-					bind:value={timestamp}
-					onkeydown={handleKeydown}
-					placeholder="202501011200"
-					class="w-full rounded border border-gray-300 px-3 py-2 focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
-					maxlength="12"
-				/>
-				{#if error}
-					<div class="mt-1 text-sm text-red-600">{error}</div>
-				{/if}
+<div class="app-content-shell">
+	<section class="surface-card">
+		<div class="surface-card-header">
+			<div>
+				<h1 class="text-2xl font-bold text-slate-900">NetFlow Files</h1>
+				<p class="text-sm text-slate-600">Open a processed file directly from its timestamp key</p>
 			</div>
-			<button
-				onclick={navigateToFile}
-				class="rounded bg-blue-600 px-4 py-2 text-white hover:bg-blue-700 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:outline-none"
-			>
-				Go to File
-			</button>
 		</div>
-		<p class="mt-2 text-sm text-gray-600">
-			Enter the exact 12-digit timestamp from NetFlow filenames (e.g., nfcapd.202501011200)
-		</p>
-	</div>
+		<div class="surface-card-body">
+			<div class="rounded-lg border border-cyan-200/70 bg-cyan-50/60 p-4">
+				<h2 class="mb-3 text-lg font-semibold text-slate-900">Navigate by Timestamp</h2>
+				<div class="flex flex-col gap-3 md:flex-row md:items-end">
+					<div class="flex-1">
+						<label for="timestamp" class="mb-1 block text-sm font-medium text-slate-700">
+							File Timestamp (YYYYMMDDHHmm)
+						</label>
+						<input
+							id="timestamp"
+							type="text"
+							bind:value={timestamp}
+							onkeydown={handleKeydown}
+							placeholder="202501011200"
+							class="control-input w-full"
+							maxlength="12"
+						/>
+						{#if error}
+							<div class="mt-1 text-sm text-red-700">{error}</div>
+						{/if}
+					</div>
+					<button onclick={navigateToFile} class="btn-primary"> Go to File </button>
+				</div>
+				<p class="mt-2 text-sm text-slate-600">
+					Enter the exact 12-digit timestamp from NetFlow filenames, for example
+					<code class="rounded bg-slate-100 px-1 py-0.5">nfcapd.202501011200</code>.
+				</p>
+			</div>
+		</div>
+	</section>
 </div>


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Comprehensive UI refactor that introduces a unified design system across the entire SvelteKit frontend. Replaces ad-hoc Tailwind utility classes with reusable CSS classes (`surface-card`, `btn-primary`, `chart-frame`, `status-panel`, etc.) defined in `app.css`, switches the color palette from gray/blue to slate/cyan, updates fonts from Inter to Manrope + Space Grotesk, and adds a subtle gradient background. Also cleans up extensive `console.log` debug statements from chart and data-loading code.

- **Design system**: New `app.css` classes (`surface-card`, `surface-card-header`, `surface-card-body`, `btn-primary`, `btn-muted`, `control-input`, `chart-frame`, `status-panel`, `nav-link`) replace duplicated inline Tailwind classes across 15+ components
- **Debug cleanup**: Removes ~40 `console.log` calls from `ChartContainer.svelte`, `StructureFunctionChart.svelte`, `SpectrumChart.svelte`, and the file detail page
- **Layout improvements**: Sticky header with backdrop-blur, active nav link highlighting via `$app/state`, hero section on dashboard, card-based file detail page with metadata tiles
- **Filter enhancements**: `RouterFilter` and `MetricSelector` gain All/None toggle buttons and selected-count indicators
- **No logic changes**: All chart interactions, data fetching, drill-down behavior, and API endpoints remain unchanged

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it is a purely presentational refactor with no logic or API changes.
- Score of 4 reflects that all changes are CSS/markup-only with no behavioral modifications. Debug log removal is a clean improvement. One minor style inconsistency (header vs content max-width) exists but is likely intentional. The dead-code empty-state guard in the file detail page is harmless.
- Pay attention to `netflow-webapp/src/routes/+layout.svelte` (header/content width mismatch) and `netflow-webapp/src/routes/api/netflow/files/[slug]/+page.svelte` (unreachable empty-state branch).

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| netflow-webapp/src/app.css | Introduces a unified design system with reusable CSS classes (surface-card, btn-primary, chart-frame, etc.), switches fonts from Inter to Manrope/Space Grotesk, and adds a subtle gradient background. |
| netflow-webapp/src/lib/components/charts/ChartContainer.svelte | Removes extensive console.log debug statements from chart click/drill-down logic. Also reformats long function signatures and x-axis config indentation. No behavioral changes. |
| netflow-webapp/src/lib/components/filters/MetricSelector.svelte | Adds selected count display, reorganizes quick-select buttons with All/None above category buttons, uses btn-muted class. Adds card-like styling to metric checkboxes. |
| netflow-webapp/src/lib/components/filters/PrimaryFilters.svelte | Adopts surface-card layout, adds derived counters for selected routers/metrics shown in header subtitle, wraps filter sections in nested bordered panels. |
| netflow-webapp/src/lib/components/filters/RouterFilter.svelte | Adds All/None toggle buttons, empty state message, selected count header, and card-like checkbox styling with btn-muted and cyan focus colors. |
| netflow-webapp/src/routes/+layout.svelte | Makes header sticky with backdrop-blur, adds active nav link highlighting using page state, switches to max-w-7xl. Note: header max-width (80rem) differs from content max-width (90rem). |
| netflow-webapp/src/routes/+page.svelte | Adds hero section with dashboard title/description, switches to app-content-shell layout class, removes bg-gray-100 in favor of global gradient background. |
| netflow-webapp/src/routes/api/netflow/files/[slug]/+page.svelte | Major restructuring to card-based layout with surface-card sections. Removes console.log debug statements. Adds empty-state guard for data.summary but it's unreachable due to server-side 404. Switches grid breakpoints from lg to xl. |

</details>



<h3>Flowchart</h3>

```mermaid
flowchart TD
    A["app.css<br/>Design System Classes"] --> B["surface-card<br/>surface-card-header<br/>surface-card-body"]
    A --> C["btn-primary<br/>btn-muted"]
    A --> D["control-input"]
    A --> E["chart-frame<br/>chart-frame-tall"]
    A --> F["status-panel<br/>status-panel-error"]
    A --> G["nav-link<br/>nav-link-active"]
    A --> H["app-content-shell"]

    B --> I["NetflowDashboard"]
    B --> J["IPChart"]
    B --> K["ProtocolChart"]
    B --> L["SpectrumStatsChart"]
    B --> M["PrimaryFilters"]
    B --> N["+error.svelte"]
    B --> O["files/+page.svelte"]
    B --> P["files/slug/+page.svelte"]

    C --> Q["ChartControls"]
    C --> N
    C --> O
    C --> P

    D --> Q
    D --> R["DateRangeFilter"]
    D --> M
    D --> O

    E --> I
    E --> J
    E --> K
    E --> L

    F --> I
    F --> J
    F --> K
    F --> L

    G --> S["+layout.svelte"]
    H --> T["+page.svelte"]
    H --> N
    H --> O
    H --> P
```

<sub>Last reviewed commit: 6deb441</sub>

<!-- greptile_other_comments_section -->

<details><summary><h4>Context used (3)</h4></summary>

- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=7aea0312-a002-45e6-8e0a-d2380aa2087c))
- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=5c231a47-c41e-48e6-a3a8-c5b60cb3b870))
- Context from `dashboard` - .cursor/rules/svelte.mdc ([source](https://app.greptile.com/review/custom-context?memory=591a6ea0-1733-46da-9c1e-60a7c778920e))
</details>


<!-- /greptile_comment -->