### PR TITLE
feat(webapp): attach chart-specific filters and refine netflow controls

### DIFF
--- a/netflow-webapp/src/lib/components/charts/IPChart.svelte
+++ b/netflow-webapp/src/lib/components/charts/IPChart.svelte
@@ -50,6 +50,7 @@
 	const dispatch = createEventDispatcher<{
 		dateChange: { startDate: string; endDate: string };
 		groupByChange: { groupBy: GroupByOption };
+		metricsChange: { metrics: IpMetricKey[] };
 	}>();
 
 	const props = $props<{
@@ -213,6 +214,14 @@
 			startDate: formatDate(start),
 			endDate: formatDate(end)
 		});
+	}
+
+	function handleMetricToggle(metric: IpMetricKey) {
+		const nextMetrics = activeMetrics.includes(metric)
+			? activeMetrics.filter((item) => item !== metric)
+			: [...activeMetrics, metric];
+		activeMetrics = nextMetrics;
+		dispatch('metricsChange', { metrics: nextMetrics });
 	}
 
 	function getLabelFromIndex(index: number): string | null {
@@ -578,12 +587,15 @@
 
 <div class="rounded-lg border bg-white shadow-sm">
 	<div
-		class="relative border-b p-4 select-none cursor-grab active:cursor-grabbing"
+		class="relative cursor-grab border-b p-4 select-none active:cursor-grabbing"
 		draggable="true"
 		data-drag-handle
 	>
 		<h3 class="text-lg font-semibold text-gray-900">Unique IP Counts</h3>
-		<span class="pointer-events-none absolute inset-0 flex items-start justify-center pt-1 text-gray-400" aria-hidden="true">
+		<span
+			class="pointer-events-none absolute inset-0 flex items-start justify-center pt-1 text-gray-400"
+			aria-hidden="true"
+		>
 			<span class="grid grid-cols-3 grid-rows-2 gap-[2px]">
 				<span class="h-[2px] w-[2px] rounded-full bg-current"></span>
 				<span class="h-[2px] w-[2px] rounded-full bg-current"></span>
@@ -595,6 +607,20 @@
 		</span>
 	</div>
 	<div class="p-4">
+		<div class="mb-4 flex flex-wrap items-center gap-4">
+			{#each IP_METRIC_OPTIONS as option (option.key)}
+				<label class="flex cursor-pointer items-center gap-2">
+					<input
+						type="checkbox"
+						checked={activeMetrics.includes(option.key)}
+						onchange={() => handleMetricToggle(option.key)}
+						class="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+					/>
+					<span class="text-sm text-gray-700">{option.label}</span>
+				</label>
+			{/each}
+		</div>
+
 		<div
 			class="h-[320px] min-h-[240px] resize-y overflow-auto rounded-md border border-gray-200 bg-white/60"
 		>

--- a/netflow-webapp/src/lib/components/charts/ProtocolChart.svelte
+++ b/netflow-webapp/src/lib/components/charts/ProtocolChart.svelte
@@ -50,6 +50,7 @@
 	const dispatch = createEventDispatcher<{
 		dateChange: { startDate: string; endDate: string };
 		groupByChange: { groupBy: GroupByOption };
+		metricsChange: { metrics: ProtocolMetricKey[] };
 	}>();
 
 	const props = $props<{
@@ -202,6 +203,14 @@
 			startDate: formatDate(start),
 			endDate: formatDate(end)
 		});
+	}
+
+	function handleMetricToggle(metric: ProtocolMetricKey) {
+		const nextMetrics = activeMetrics.includes(metric)
+			? activeMetrics.filter((item) => item !== metric)
+			: [...activeMetrics, metric];
+		activeMetrics = nextMetrics;
+		dispatch('metricsChange', { metrics: nextMetrics });
 	}
 
 	function getLabelFromIndex(index: number): string | null {
@@ -529,12 +538,15 @@
 
 <div class="rounded-lg border bg-white shadow-sm">
 	<div
-		class="relative border-b p-4 select-none cursor-grab active:cursor-grabbing"
+		class="relative cursor-grab border-b p-4 select-none active:cursor-grabbing"
 		draggable="true"
 		data-drag-handle
 	>
 		<h3 class="text-lg font-semibold text-gray-900">Unique Protocol Counts</h3>
-		<span class="pointer-events-none absolute inset-0 flex items-start justify-center pt-1 text-gray-400" aria-hidden="true">
+		<span
+			class="pointer-events-none absolute inset-0 flex items-start justify-center pt-1 text-gray-400"
+			aria-hidden="true"
+		>
 			<span class="grid grid-cols-3 grid-rows-2 gap-[2px]">
 				<span class="h-[2px] w-[2px] rounded-full bg-current"></span>
 				<span class="h-[2px] w-[2px] rounded-full bg-current"></span>
@@ -546,6 +558,22 @@
 		</span>
 	</div>
 	<div class="p-4">
+		<div class="mb-4 flex flex-wrap items-center gap-4">
+			{#each ['uniqueProtocolsIpv4', 'uniqueProtocolsIpv6'] as const as key (key)}
+				<label class="flex cursor-pointer items-center gap-2">
+					<input
+						type="checkbox"
+						checked={activeMetrics.includes(key)}
+						onchange={() => handleMetricToggle(key)}
+						class="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+					/>
+					<span class="text-sm text-gray-700">
+						{key === 'uniqueProtocolsIpv4' ? 'Unique Protocols IPv4' : 'Unique Protocols IPv6'}
+					</span>
+				</label>
+			{/each}
+		</div>
+
 		<div
 			class="h-[320px] min-h-[240px] resize-y overflow-auto rounded-md border border-gray-200 bg-white/60"
 		>

--- a/netflow-webapp/src/lib/components/charts/SpectrumStatsChart.svelte
+++ b/netflow-webapp/src/lib/components/charts/SpectrumStatsChart.svelte
@@ -45,11 +45,14 @@
 		granularity?: IpGranularity;
 		router?: string;
 		addressType?: 'sa' | 'da';
+		availableRouters?: string[];
 	}>();
 
 	const dispatch = createEventDispatcher<{
 		dateChange: { startDate: string; endDate: string };
 		groupByChange: { groupBy: GroupByOption };
+		routerChange: { router: string };
+		addressTypeChange: { addressType: 'sa' | 'da' };
 	}>();
 
 	const today = new Date();
@@ -186,6 +189,21 @@
 			startDate: formatDate(start),
 			endDate: formatDate(end)
 		});
+	}
+
+	function handleRouterChange(router: string) {
+		if (router === (props.router ?? '')) {
+			return;
+		}
+		dispatch('routerChange', { router });
+	}
+
+	function handleAddressTypeChange(nextAddressType: 'sa' | 'da') {
+		if (nextAddressType === addressType) {
+			return;
+		}
+		addressType = nextAddressType;
+		dispatch('addressTypeChange', { addressType: nextAddressType });
 	}
 
 	function getLabelFromIndex(index: number): string | null {
@@ -650,12 +668,15 @@
 
 <div class="rounded-lg border bg-white shadow-sm">
 	<div
-		class="relative border-b p-4 select-none cursor-grab active:cursor-grabbing"
+		class="relative cursor-grab border-b p-4 select-none active:cursor-grabbing"
 		draggable="true"
 		data-drag-handle
 	>
 		<h3 class="text-lg font-semibold text-gray-900">Spectrum</h3>
-		<span class="pointer-events-none absolute inset-0 flex items-start justify-center pt-1 text-gray-400" aria-hidden="true">
+		<span
+			class="pointer-events-none absolute inset-0 flex items-start justify-center pt-1 text-gray-400"
+			aria-hidden="true"
+		>
 			<span class="grid grid-cols-3 grid-rows-2 gap-[2px]">
 				<span class="h-[2px] w-[2px] rounded-full bg-current"></span>
 				<span class="h-[2px] w-[2px] rounded-full bg-current"></span>
@@ -667,6 +688,49 @@
 		</span>
 	</div>
 	<div class="p-4">
+		<div class="mb-4 space-y-2">
+			<div class="flex min-h-6 flex-wrap items-center gap-4">
+				{#if (props.availableRouters ?? []).length === 0}
+					<span class="text-sm text-gray-500">No enabled routers selected.</span>
+				{:else}
+					{#each props.availableRouters ?? [] as routerName (routerName)}
+						<label class="flex cursor-pointer items-center gap-2">
+							<input
+								type="radio"
+								name="spectrum-router-local"
+								checked={props.router === routerName}
+								onchange={() => handleRouterChange(routerName)}
+								class="h-4 w-4 border-gray-300 text-blue-600 focus:ring-blue-500"
+							/>
+							<span class="text-sm text-gray-700">{routerName}</span>
+						</label>
+					{/each}
+				{/if}
+			</div>
+			<div class="flex flex-wrap items-center gap-4">
+				<label class="flex cursor-pointer items-center gap-2">
+					<input
+						type="radio"
+						name="spectrum-address-type-local"
+						checked={addressType === 'sa'}
+						onchange={() => handleAddressTypeChange('sa')}
+						class="h-4 w-4 border-gray-300 text-blue-600 focus:ring-blue-500"
+					/>
+					<span class="text-sm text-gray-700">Source IPv4</span>
+				</label>
+				<label class="flex cursor-pointer items-center gap-2">
+					<input
+						type="radio"
+						name="spectrum-address-type-local"
+						checked={addressType === 'da'}
+						onchange={() => handleAddressTypeChange('da')}
+						class="h-4 w-4 border-gray-300 text-blue-600 focus:ring-blue-500"
+					/>
+					<span class="text-sm text-gray-700">Destination IPv4</span>
+				</label>
+			</div>
+		</div>
+
 		<div
 			class="h-[400px] min-h-[300px] resize-y overflow-auto rounded-md border border-gray-200 bg-white/60"
 		>

--- a/netflow-webapp/src/lib/components/filters/MetricSelector.svelte
+++ b/netflow-webapp/src/lib/components/filters/MetricSelector.svelte
@@ -1,12 +1,14 @@
 <script lang="ts">
-	import type { DataOption } from '$lib/components/netflow/types.ts';
+	import type { ChartTypeOption, DataOption } from '$lib/components/netflow/types.ts';
 
 	interface Props {
 		dataOptions: DataOption[];
 		onDataOptionsChange?: (dataOptions: DataOption[]) => void;
+		chartType?: ChartTypeOption;
+		onChartTypeChange?: (chartType: ChartTypeOption) => void;
 	}
 
-	let { dataOptions, onDataOptionsChange }: Props = $props();
+	let { dataOptions, onDataOptionsChange, chartType, onChartTypeChange }: Props = $props();
 
 	function handleMetricToggle(index: number) {
 		const newDataOptions = dataOptions.map((option, i) =>
@@ -37,46 +39,73 @@
 		const newDataOptions = dataOptions.map((option) => ({ ...option, checked: false }));
 		onDataOptionsChange?.(newDataOptions);
 	}
+
+	function handleChartTypeChange(event: Event) {
+		if (!onChartTypeChange) {
+			return;
+		}
+		const target = event.currentTarget as HTMLSelectElement;
+		onChartTypeChange(target.value as ChartTypeOption);
+	}
 </script>
 
 <div class="metric-selector">
-	<div class="mb-4 flex flex-wrap gap-2">
-		<span class="text-sm font-medium text-gray-700">Quick Select:</span>
-		<button
-			type="button"
-			onclick={() => handleQuickSelect('flows')}
-			class="rounded-md bg-green-100 px-3 py-1 text-xs text-green-800 hover:bg-green-200 focus:ring-2 focus:ring-green-500 focus:outline-none"
-		>
-			All Flows
-		</button>
-		<button
-			type="button"
-			onclick={() => handleQuickSelect('packets')}
-			class="rounded-md bg-blue-100 px-3 py-1 text-xs text-blue-800 hover:bg-blue-200 focus:ring-2 focus:ring-blue-500 focus:outline-none"
-		>
-			All Packets
-		</button>
-		<button
-			type="button"
-			onclick={() => handleQuickSelect('bytes')}
-			class="rounded-md bg-purple-100 px-3 py-1 text-xs text-purple-800 hover:bg-purple-200 focus:ring-2 focus:ring-purple-500 focus:outline-none"
-		>
-			All Bytes
-		</button>
-		<button
-			type="button"
-			onclick={handleSelectAll}
-			class="rounded-md bg-gray-100 px-3 py-1 text-xs text-gray-800 hover:bg-gray-200 focus:ring-2 focus:ring-gray-500 focus:outline-none"
-		>
-			Select All
-		</button>
-		<button
-			type="button"
-			onclick={handleSelectNone}
-			class="rounded-md bg-gray-100 px-3 py-1 text-xs text-gray-800 hover:bg-gray-200 focus:ring-2 focus:ring-gray-500 focus:outline-none"
-		>
-			Select None
-		</button>
+	<div class="mb-4 flex flex-wrap items-center justify-between gap-3">
+		<div class="flex flex-wrap items-center gap-2">
+			<span class="text-sm font-medium text-gray-700">Quick Select:</span>
+			<button
+				type="button"
+				onclick={() => handleQuickSelect('flows')}
+				class="rounded-md bg-green-100 px-3 py-1 text-xs text-green-800 hover:bg-green-200 focus:ring-2 focus:ring-green-500 focus:outline-none"
+			>
+				All Flows
+			</button>
+			<button
+				type="button"
+				onclick={() => handleQuickSelect('packets')}
+				class="rounded-md bg-blue-100 px-3 py-1 text-xs text-blue-800 hover:bg-blue-200 focus:ring-2 focus:ring-blue-500 focus:outline-none"
+			>
+				All Packets
+			</button>
+			<button
+				type="button"
+				onclick={() => handleQuickSelect('bytes')}
+				class="rounded-md bg-purple-100 px-3 py-1 text-xs text-purple-800 hover:bg-purple-200 focus:ring-2 focus:ring-purple-500 focus:outline-none"
+			>
+				All Bytes
+			</button>
+			<button
+				type="button"
+				onclick={handleSelectAll}
+				class="rounded-md bg-gray-100 px-3 py-1 text-xs text-gray-800 hover:bg-gray-200 focus:ring-2 focus:ring-gray-500 focus:outline-none"
+			>
+				Select All
+			</button>
+			<button
+				type="button"
+				onclick={handleSelectNone}
+				class="rounded-md bg-gray-100 px-3 py-1 text-xs text-gray-800 hover:bg-gray-200 focus:ring-2 focus:ring-gray-500 focus:outline-none"
+			>
+				Select None
+			</button>
+		</div>
+
+		{#if chartType}
+			<div class="flex items-center">
+				<label class="text-sm text-gray-600">
+					Chart type
+					<select
+						value={chartType}
+						onchange={handleChartTypeChange}
+						class="ml-2 rounded border border-gray-300 bg-white px-2 py-1 text-sm text-gray-700 focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+						aria-label="Select NetFlow chart type"
+					>
+						<option value="stacked">Stacked Area</option>
+						<option value="line">Line Chart</option>
+					</select>
+				</label>
+			</div>
+		{/if}
 	</div>
 
 	<div class="grid grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-5">

--- a/netflow-webapp/src/routes/+page.svelte
+++ b/netflow-webapp/src/routes/+page.svelte
@@ -44,6 +44,7 @@
 	};
 
 	const ipGranularity = $derived(GROUP_BY_TO_IP[selectedGroupBy]);
+	const availableSpectrumRouters = $derived(getEnabledRouters(selectedRouters));
 
 	function isValidChartOrder(value: unknown): value is ChartCardId[] {
 		if (!Array.isArray(value)) {
@@ -279,6 +280,15 @@
 	function handleIpMetricsChange(event: CustomEvent<{ metrics: IpMetricKey[] }>) {
 		ipMetrics = event.detail.metrics;
 	}
+
+	function handleResetView() {
+		const defaultStartDate = '2025-02-11';
+		const today = new Date().toJSON().slice(0, 10);
+		selectedGroupBy = 'date';
+		startDate = defaultStartDate;
+		endDate = today;
+		params.update({ groupBy: selectedGroupBy, startDate, endDate });
+	}
 </script>
 
 <svelte:head>
@@ -293,26 +303,11 @@
 			{endDate}
 			groupBy={selectedGroupBy}
 			routers={selectedRouters}
-			spectrumRouter={selectedSpectrumRouter}
-			spectrumAddressType={selectedSpectrumAddressType}
-			{dataOptions}
-			{ipMetrics}
-			{protocolMetrics}
 			on:startDateChange={handleStartDateChange}
 			on:endDateChange={handleEndDateChange}
 			on:groupByChange={handleGroupByChange}
 			on:routersChange={handleRoutersChange}
-			on:spectrumRouterChange={(event) => {
-				selectedSpectrumRouter = event.detail.router;
-			}}
-			on:spectrumAddressTypeChange={(event) => {
-				selectedSpectrumAddressType = event.detail.addressType;
-			}}
-			on:dataOptionsChange={handleDataOptionsChange}
-			on:ipMetricsChange={handleIpMetricsChange}
-			on:protocolMetricsChange={(event) => {
-				protocolMetrics = event.detail.metrics;
-			}}
+			on:resetView={handleResetView}
 		/>
 
 		<div role="list" aria-label="Reorderable charts" class="flex flex-col gap-2">
@@ -344,6 +339,7 @@
 							{dataOptions}
 							on:dateChange={handleDateChange}
 							on:groupByChange={handleGroupByChange}
+							on:dataOptionsChange={handleDataOptionsChange}
 						/>
 					{:else if chartId === 'ip'}
 						<IPChart
@@ -354,6 +350,7 @@
 							activeMetrics={ipMetrics}
 							on:dateChange={handleDateChange}
 							on:groupByChange={handleGroupByChange}
+							on:metricsChange={handleIpMetricsChange}
 						/>
 					{:else if chartId === 'protocol'}
 						<ProtocolChart
@@ -364,6 +361,9 @@
 							activeMetrics={protocolMetrics}
 							on:dateChange={handleDateChange}
 							on:groupByChange={handleGroupByChange}
+							on:metricsChange={(event) => {
+								protocolMetrics = event.detail.metrics;
+							}}
 						/>
 					{:else}
 						<SpectrumStatsChart
@@ -372,8 +372,15 @@
 							granularity={ipGranularity}
 							router={selectedSpectrumRouter}
 							addressType={selectedSpectrumAddressType}
+							availableRouters={availableSpectrumRouters}
 							on:dateChange={handleDateChange}
 							on:groupByChange={handleGroupByChange}
+							on:routerChange={(event) => {
+								selectedSpectrumRouter = event.detail.router;
+							}}
+							on:addressTypeChange={(event) => {
+								selectedSpectrumAddressType = event.detail.addressType;
+							}}
 						/>
 					{/if}
 				</section>


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR relocates chart-specific filter controls (metric toggles, router/address-type selectors, chart type picker) from the centralized `PrimaryFilters` panel into each individual chart component (`IPChart`, `ProtocolChart`, `SpectrumStatsChart`, `NetflowDashboard`). The `PrimaryFilters` component is simplified to only manage shared concerns: date range, granularity, router selection, and a new "Reset View" button.

- **Decentralized chart filters**: Each chart now owns its relevant filter UI (metric checkboxes, router radio buttons, address type selectors) and dispatches change events upward to `+page.svelte`.
- **`MetricSelector` extended**: Absorbs the chart type dropdown previously in `ChartControls`, which is now unused and can be removed.
- **`PrimaryFilters` slimmed**: Removes ~90 lines of chart-specific controls and adds a `resetView` event/button.
- **`+page.svelte` wiring**: New event handlers (`on:metricsChange`, `on:dataOptionsChange`, `on:routerChange`, `on:addressTypeChange`) connect the chart-local controls to page-level state. Adds `availableSpectrumRouters` derived state.
- **Formatting**: Minor Tailwind class reordering and multi-line formatting of drag-handle markup across all chart components.

<h3>Confidence Score: 4/5</h3>

- This PR is a clean UI restructuring with low risk; the main concern is the previously-flagged address type re-render bug in SpectrumStatsChart.
- The refactoring correctly moves filter controls into their respective chart components with proper event dispatch wiring. No new logic bugs were introduced. The one pre-existing issue (address type change not triggering re-render in SpectrumStatsChart) was already flagged in a prior review. Minor cleanup opportunity with the now-unused ChartControls component.
- netflow-webapp/src/lib/components/charts/SpectrumStatsChart.svelte (pre-existing address type re-render issue), netflow-webapp/src/lib/components/charts/ChartControls.svelte (dead code to remove)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| netflow-webapp/src/lib/components/charts/IPChart.svelte | Adds inline metric toggle checkboxes and dispatches `metricsChange` event to parent. Clean implementation consistent with existing patterns. |
| netflow-webapp/src/lib/components/charts/ProtocolChart.svelte | Adds inline metric toggle checkboxes and dispatches `metricsChange` event. Mirrors IPChart pattern. |
| netflow-webapp/src/lib/components/charts/SpectrumStatsChart.svelte | Moves router and address type selectors inline. Adds `availableRouters` prop and dispatches `routerChange`/`addressTypeChange` events. Address type change re-render bug flagged in prior review. |
| netflow-webapp/src/lib/components/filters/MetricSelector.svelte | Extended with optional `chartType` prop and `onChartTypeChange` callback for chart type selection, previously in ChartControls. |
| netflow-webapp/src/lib/components/filters/PrimaryFilters.svelte | Significantly simplified by removing chart-specific filter state and controls. Now only manages date, granularity, routers, and a new Reset View button. |
| netflow-webapp/src/lib/components/netflow/NetflowDashboard.svelte | Replaces ChartControls with MetricSelector for inline data option and chart type management. Dispatches `dataOptionsChange` up to page. Removes reset/groupBy handlers that moved to PrimaryFilters. |
| netflow-webapp/src/routes/+page.svelte | Wires up new chart-specific events (`metricsChange`, `dataOptionsChange`, `routerChange`, `addressTypeChange`). Adds `handleResetView` and `availableSpectrumRouters` derived state. Simplifies PrimaryFilters prop surface. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    Page["+page.svelte\n(Page-level state)"]
    PF["PrimaryFilters\n(Date, Granularity, Routers, Reset)"]
    NF["NetflowDashboard\n(MetricSelector + ChartContainer)"]
    IP["IPChart\n(Inline metric checkboxes)"]
    Proto["ProtocolChart\n(Inline metric checkboxes)"]
    Spec["SpectrumStatsChart\n(Inline router + address type radios)"]

    Page -->|"startDate, endDate, groupBy, routers"| PF
    PF -->|"on:resetView, on:groupByChange, on:routersChange"| Page

    Page -->|"dataOptions, routers, dates, groupBy"| NF
    NF -->|"on:dataOptionsChange, on:dateChange, on:groupByChange"| Page

    Page -->|"ipMetrics, routers, dates, granularity"| IP
    IP -->|"on:metricsChange, on:dateChange, on:groupByChange"| Page

    Page -->|"protocolMetrics, routers, dates, granularity"| Proto
    Proto -->|"on:metricsChange, on:dateChange, on:groupByChange"| Page

    Page -->|"router, addressType, availableRouters, dates, granularity"| Spec
    Spec -->|"on:routerChange, on:addressTypeChange, on:dateChange, on:groupByChange"| Page
```

<sub>Last reviewed commit: c8a815a</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=7aea0312-a002-45e6-8e0a-d2380aa2087c))
- Context from `dashboard` - .cursor/rules/svelte.mdc ([source](https://app.greptile.com/review/custom-context?memory=591a6ea0-1733-46da-9c1e-60a7c778920e))

<!-- /greptile_comment -->