### PR TITLE
feat(pipeline): add configurable reprocessing window

### DIFF
--- a/docs/pipeline-usage.md
+++ b/docs/pipeline-usage.md
@@ -1,0 +1,110 @@
+# Pipeline usage
+
+The pipeline lives in `netflow-db/pipeline.py`.
+
+It does two things:
+
+- discovers files and recent gaps
+- processes pending data into the stats tables
+
+## Normal run
+
+From the repo root:
+
+```bash
+python netflow-db/pipeline.py
+```
+
+That uses the default reprocessing window of 30 days.
+
+In practice, that means:
+
+- recent missing data can still be discovered and filled in
+- recent stale days can be reopened and rebuilt
+- older history stays recorded in `processed_files`, but is not automatically revisited in that run
+
+## Common flags
+
+Only do discovery:
+
+```bash
+python netflow-db/pipeline.py --discover-only
+```
+
+Only do processing:
+
+```bash
+python netflow-db/pipeline.py --process-only
+```
+
+Only run specific tables:
+
+```bash
+python netflow-db/pipeline.py --tables flow_stats,ip_stats
+```
+
+Limit how much work is done per table:
+
+```bash
+python netflow-db/pipeline.py --limit 500
+```
+
+Disable log-file output:
+
+```bash
+python netflow-db/pipeline.py --no-log
+```
+
+## Delayed uploads
+
+If data showed up late and you need to revisit older days, widen the reprocessing window.
+
+Example: look back 90 days
+
+```bash
+python netflow-db/pipeline.py --reprocess-window-days 90
+```
+
+Example: full historical reconciliation
+
+```bash
+python netflow-db/pipeline.py --reprocess-window-days 0
+```
+
+`0` means unlimited.
+
+The selected window is the control knob for that run:
+
+- files outside the window are left alone
+- stale days inside the window can be reopened and rebuilt
+
+A practical pattern is:
+
+- weekly: run a 14-day window
+- monthly: run a wider window like 90 days
+
+That gives you regular recent updates plus a periodic deeper reconciliation pass.
+
+## Important detail about aggregates
+
+`flow_stats` can be updated file by file.
+
+The aggregate-heavy tables work at the day level:
+
+- `ip_stats`
+- `protocol_stats`
+- `spectrum_stats`
+- `structure_stats`
+
+If any file in a day needs to be revisited for one of those tables, the pipeline reopens and rebuilds that whole day for that table.
+
+So if you know delayed uploads affected older history, use a larger `--reprocess-window-days` value when you rerun the pipeline.
+
+## Sanity check
+
+If you edited backend Python, run:
+
+```bash
+cd netflow-db
+python -m py_compile *.py
+```

--- a/netflow-db/discovery.py
+++ b/netflow-db/discovery.py
@@ -8,7 +8,7 @@ import os
 import sqlite3
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Iterator
+from typing import Iterator, Optional
 
 from common import (
     NETFLOW_DATA_PATH,
@@ -133,7 +133,32 @@ def identify_gaps(
     return gaps
 
 
-def sync_processed_files_table(conn: sqlite3.Connection, include_gaps: bool = True) -> dict:
+def get_reprocess_cutoff_dt(reprocess_window_days: int = 30) -> Optional[datetime]:
+    """
+    Return the start-of-day cutoff for the active reprocessing window.
+
+    Args:
+        reprocess_window_days: Number of days to include. ``0`` means unlimited.
+
+    Returns:
+        Datetime at local midnight for the cutoff day, or None when unlimited.
+    """
+    if reprocess_window_days == 0:
+        return None
+    if reprocess_window_days < 0:
+        raise ValueError("reprocess_window_days must be >= 0")
+
+    return (
+        datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+        - timedelta(days=reprocess_window_days)
+    )
+
+
+def sync_processed_files_table(
+    conn: sqlite3.Connection,
+    include_gaps: bool = True,
+    reprocess_window_days: int = 30
+) -> dict:
     """
     Synchronize the processed_files table with the filesystem.
     
@@ -145,6 +170,7 @@ def sync_processed_files_table(conn: sqlite3.Connection, include_gaps: bool = Tr
     Args:
         conn: Database connection
         include_gaps: If True, also insert gap placeholders (file_exists=0)
+        reprocess_window_days: Gap detection window in days. ``0`` means unlimited.
         
     Returns:
         Dictionary with counts: {'discovered': N, 'new_files': N, 'gaps': N}
@@ -185,6 +211,8 @@ def sync_processed_files_table(conn: sqlite3.Connection, include_gaps: bool = Tr
     data_horizon = compute_data_horizon(conn)
     print(f"Data horizon: {data_horizon}")
     
+    cutoff_dt = get_reprocess_cutoff_dt(reprocess_window_days)
+
     for router in AVAILABLE_ROUTERS:
         # Find the earliest timestamp for this router
         row = cursor.execute("""
@@ -197,7 +225,13 @@ def sync_processed_files_table(conn: sqlite3.Connection, include_gaps: bool = Tr
             continue
         
         router_start = datetime.fromtimestamp(row[0])
-        gaps = identify_gaps(conn, router, router_start, data_horizon)
+        gap_start = router_start if cutoff_dt is None else max(router_start, cutoff_dt)
+
+        if gap_start >= data_horizon:
+            print(f"  Router {router}: no gap scan needed within active window")
+            continue
+
+        gaps = identify_gaps(conn, router, gap_start, data_horizon)
         
         for gap_timestamp in gaps:
             # Construct the expected file path for this gap
@@ -220,31 +254,50 @@ def sync_processed_files_table(conn: sqlite3.Connection, include_gaps: bool = Tr
     return stats
 
 
-def get_pending_files(conn: sqlite3.Connection, limit: int = None) -> list[tuple[str, str, int, bool]]:
+def get_pending_files(
+    conn: sqlite3.Connection,
+    limit: int = None,
+    reprocess_window_days: int = 30
+) -> list[tuple[str, str, int, bool]]:
     """
     Get files that haven't been fully processed yet.
     
     Args:
         conn: Database connection
         limit: Optional limit on number of files to return
+        reprocess_window_days: Processing window in days. ``0`` means unlimited.
         
     Returns:
         List of tuples: (file_path, router, timestamp, file_exists)
     """
     cursor = conn.cursor()
-    
+
+    cutoff_dt = get_reprocess_cutoff_dt(reprocess_window_days)
+    cutoff_unix = None if cutoff_dt is None else timestamp_to_unix(cutoff_dt)
+
     query = """
         SELECT file_path, router, timestamp, file_exists
         FROM processed_files
         WHERE processed_at IS NULL
-        ORDER BY timestamp ASC
     """
-    
-    if limit:
-        query += f" LIMIT {limit}"
-    
-    rows = cursor.execute(query).fetchall()
-    return [(row[0], row[1], row[2], bool(row[3])) for row in rows]
+    params: list[int] = []
+
+    if cutoff_unix is not None:
+        # Real files stay eligible regardless of age; only synthetic gaps are windowed.
+        query += " AND (file_exists = 1 OR timestamp >= ?)"
+        params.append(cutoff_unix)
+
+    query += " ORDER BY timestamp ASC"
+
+    rows = cursor.execute(query, params).fetchall()
+
+    pending = []
+    for file_path, router, timestamp, file_exists in rows:
+        pending.append((file_path, router, timestamp, bool(file_exists)))
+        if limit and len(pending) >= limit:
+            break
+
+    return pending
 
 
 def get_complete_days(conn: sqlite3.Connection) -> set[tuple[str, int]]:
@@ -283,7 +336,8 @@ def get_files_needing_processing(
     conn: sqlite3.Connection, 
     table_name: str,
     limit: int = None,
-    complete_days_only: bool = True
+    complete_days_only: bool = True,
+    reprocess_window_days: int = 30
 ) -> list[tuple[str, str, int, bool]]:
     """
     Get files that need processing for a specific table.
@@ -294,6 +348,7 @@ def get_files_needing_processing(
                     'spectrum_stats', 'structure_stats'
         limit: Optional limit on number of files to return
         complete_days_only: If True (default), only return files from complete days
+        reprocess_window_days: Processing window in days. ``0`` means unlimited.
         
     Returns:
         List of tuples: (file_path, router, timestamp, file_exists)
@@ -304,36 +359,57 @@ def get_files_needing_processing(
     
     status_column = f"{table_name}_status"
     cursor = conn.cursor()
-    
+
+    cutoff_dt = get_reprocess_cutoff_dt(reprocess_window_days)
+    cutoff_unix = None if cutoff_dt is None else timestamp_to_unix(cutoff_dt)
+
     query = f"""
         SELECT file_path, router, timestamp, file_exists
         FROM processed_files
         WHERE {status_column} IS NULL
-        ORDER BY timestamp ASC
     """
-    
-    if limit:
-        query += f" LIMIT {limit}"
-    
-    rows = cursor.execute(query).fetchall()
-    
+    params: list[int] = []
+
+    if cutoff_unix is not None:
+        # Real files stay eligible regardless of age; only synthetic gaps are windowed.
+        query += " AND (file_exists = 1 OR timestamp >= ?)"
+        params.append(cutoff_unix)
+
+    query += " ORDER BY timestamp ASC"
+
     if not complete_days_only:
-        return [(row[0], row[1], row[2], bool(row[3])) for row in rows]
-    
+        if limit:
+            query += " LIMIT ?"
+            params = [*params, limit]
+        rows = cursor.execute(query, params).fetchall()
+        return [(file_path, router, timestamp, bool(file_exists)) for file_path, router, timestamp, file_exists in rows]
+
     # Filter to only complete days
     complete_days = get_complete_days(conn)
-    
+
+    batch_size = limit if limit else 1000
+    offset = 0
     result = []
-    for row in rows:
-        file_path, router, timestamp, file_exists = row
-        # Get the day start for this timestamp
-        dt = unix_to_timestamp(timestamp)
-        day_start = dt.replace(hour=0, minute=0, second=0, microsecond=0)
-        day_start_unix = timestamp_to_unix(day_start)
-        
-        if (router, day_start_unix) in complete_days:
-            result.append((file_path, router, timestamp, bool(file_exists)))
-    
+
+    while True:
+        batch_query = f"{query} LIMIT ? OFFSET ?"
+        batch_params = [*params, batch_size, offset]
+        rows = cursor.execute(batch_query, batch_params).fetchall()
+        if not rows:
+            break
+
+        for file_path, router, timestamp, file_exists in rows:
+            dt = unix_to_timestamp(timestamp)
+            day_start = dt.replace(hour=0, minute=0, second=0, microsecond=0)
+            day_start_unix = timestamp_to_unix(day_start)
+
+            if (router, day_start_unix) in complete_days:
+                result.append((file_path, router, timestamp, bool(file_exists)))
+                if limit and len(result) >= limit:
+                    return result
+
+        offset += len(rows)
+
     return result
 
 
@@ -480,7 +556,8 @@ def reset_day_for_reprocessing(
 
 def handle_stale_days(
     conn: sqlite3.Connection,
-    table_name: str
+    table_name: str,
+    reprocess_window_days: int = 30
 ) -> dict:
     """
     Detect and reset all stale days for a table.
@@ -490,6 +567,7 @@ def handle_stale_days(
     Args:
         conn: Database connection
         table_name: The table being processed
+        reprocess_window_days: Reprocessing window in days. ``0`` means unlimited.
     
     Returns:
         Dict with summary:
@@ -503,12 +581,14 @@ def handle_stale_days(
     """
     stale_days = get_stale_days(conn, table_name)
 
-    # Never auto-reset stale days older than 30 days.
-    # This prevents long-range historical rewrites when discovery finds late files.
-    cutoff_dt = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0) - timedelta(days=30)
-    cutoff_unix = timestamp_to_unix(cutoff_dt)
+    cutoff_dt = get_reprocess_cutoff_dt(reprocess_window_days)
+    cutoff_unix = None if cutoff_dt is None else timestamp_to_unix(cutoff_dt)
 
-    stale_days_recent = {(router, day_start) for router, day_start in stale_days if day_start >= cutoff_unix}
+    stale_days_recent = {
+        (router, day_start)
+        for router, day_start in stale_days
+        if cutoff_unix is None or day_start >= cutoff_unix
+    }
     stale_days_skipped_old = len(stale_days) - len(stale_days_recent)
 
     summary = {
@@ -521,14 +601,16 @@ def handle_stale_days(
 
     if not stale_days_recent:
         if stale_days_skipped_old:
+            cutoff_label = cutoff_dt.strftime('%Y-%m-%d') if cutoff_dt else 'unlimited'
             print(f"[{table_name}] Found {stale_days_skipped_old} stale days older than cutoff "
-                  f"({cutoff_dt.strftime('%Y-%m-%d')}), skipping reset")
+                  f"({cutoff_label}), skipping reset")
         return summary
 
     print(f"[{table_name}] Found {len(stale_days_recent)} stale days needing reprocessing")
     if stale_days_skipped_old:
+        cutoff_label = cutoff_dt.strftime('%Y-%m-%d') if cutoff_dt else 'unlimited'
         print(f"[{table_name}] Skipping {stale_days_skipped_old} stale days older than cutoff "
-              f"({cutoff_dt.strftime('%Y-%m-%d')})")
+              f"({cutoff_label})")
 
     for router, day_start in stale_days_recent:
         day_dt = unix_to_timestamp(day_start)

--- a/netflow-db/flow_db.py
+++ b/netflow-db/flow_db.py
@@ -209,7 +209,11 @@ def batch_insert_results(conn: sqlite3.Connection, results: list[dict]) -> int:
     return inserted
 
 
-def process_pending_files(conn: sqlite3.Connection, limit: int = None) -> dict:
+def process_pending_files(
+    conn: sqlite3.Connection,
+    limit: int = None,
+    reprocess_window_days: int = 30
+) -> dict:
     """
     Process all pending files for the netflow_stats table using parallel processing.
     
@@ -224,9 +228,14 @@ def process_pending_files(conn: sqlite3.Connection, limit: int = None) -> dict:
     
     # Handle stale days - reset days that have new files mixed with already-processed files
     # (flow_stats has no aggregates, but we reset for consistency)
-    handle_stale_days(conn, 'flow_stats')
+    handle_stale_days(conn, 'flow_stats', reprocess_window_days)
     
-    pending = get_files_needing_processing(conn, 'flow_stats', limit)
+    pending = get_files_needing_processing(
+        conn,
+        'flow_stats',
+        limit,
+        reprocess_window_days=reprocess_window_days,
+    )
     stats = {'processed': 0, 'errors': 0}
     
     if not pending:

--- a/netflow-db/ip_db.py
+++ b/netflow-db/ip_db.py
@@ -294,7 +294,11 @@ def process_day_worker(day_info: tuple) -> dict:
     }
 
 
-def process_pending_files(conn: sqlite3.Connection, limit: int = None) -> dict:
+def process_pending_files(
+    conn: sqlite3.Connection,
+    limit: int = None,
+    reprocess_window_days: int = 30
+) -> dict:
     """
     Process all pending files for the ip_stats table.
     Uses day-parallel processing where each worker handles a complete day.
@@ -302,9 +306,14 @@ def process_pending_files(conn: sqlite3.Connection, limit: int = None) -> dict:
     init_ip_stats_table(conn)
     
     # Handle stale days - reset days that have new files mixed with already-processed files
-    handle_stale_days(conn, 'ip_stats')
+    handle_stale_days(conn, 'ip_stats', reprocess_window_days)
     
-    pending = get_files_needing_processing(conn, 'ip_stats', limit)
+    pending = get_files_needing_processing(
+        conn,
+        'ip_stats',
+        limit,
+        reprocess_window_days=reprocess_window_days,
+    )
     stats = {'processed': 0, 'errors': 0, 'aggregates': 0, 'days': 0}
     
     if not pending:

--- a/netflow-db/pipeline.py
+++ b/netflow-db/pipeline.py
@@ -10,6 +10,7 @@ This is the main entry point for cron-based processing. It orchestrates:
 
 Usage:
     python pipeline.py [--discover-only] [--process-only] [--limit N] [--tables TABLE1,TABLE2]
+                       [--reprocess-window-days N]
     
 Options:
     --discover-only   Only run discovery phase, skip processing
@@ -17,6 +18,8 @@ Options:
     --limit N         Limit processing to N files per table
     --tables          Comma-separated list of tables to process (default: all)
                       Valid: flow_stats,ip_stats,protocol_stats,spectrum_stats,structure_stats
+    --reprocess-window-days N
+                      Reprocessing window in days (default: 30, 0 = unlimited)
 """
 
 import argparse
@@ -84,7 +87,7 @@ def setup_logging(log_dir: Path = None):
     return log_file
 
 
-def run_discovery(conn: sqlite3.Connection) -> dict:
+def run_discovery(conn: sqlite3.Connection, reprocess_window_days: int = 30) -> dict:
     """
     Run the file discovery phase.
     
@@ -92,6 +95,7 @@ def run_discovery(conn: sqlite3.Connection) -> dict:
     
     Args:
         conn: Database connection
+        reprocess_window_days: Reprocessing window in days. ``0`` means unlimited.
         
     Returns:
         Discovery statistics
@@ -100,13 +104,17 @@ def run_discovery(conn: sqlite3.Connection) -> dict:
     print("PHASE 1: FILE DISCOVERY")
     print("=" * 60)
     
-    stats = sync_processed_files_table(conn, include_gaps=True)
+    stats = sync_processed_files_table(
+        conn,
+        include_gaps=True,
+        reprocess_window_days=reprocess_window_days,
+    )
     
     horizon = compute_data_horizon(conn)
     print(f"\nData horizon: {horizon}")
     
     # Count pending files
-    pending = get_pending_files(conn)
+    pending = get_pending_files(conn, reprocess_window_days=reprocess_window_days)
     print(f"Total pending files: {len(pending)}")
     
     return stats
@@ -115,7 +123,8 @@ def run_discovery(conn: sqlite3.Connection) -> dict:
 def run_processing(
     conn: sqlite3.Connection,
     tables: list[str] = None,
-    limit: int = None
+    limit: int = None,
+    reprocess_window_days: int = 30
 ) -> dict:
     """
     Run the processing phase for specified tables.
@@ -124,6 +133,7 @@ def run_processing(
         conn: Database connection
         tables: List of table names to process (default: all)
         limit: Optional limit on files per table
+        reprocess_window_days: Reprocessing window in days. ``0`` means unlimited.
         
     Returns:
         Processing statistics per table
@@ -162,7 +172,7 @@ def run_processing(
             processor.init_structure_stats_table(conn)
         
         # Process pending files
-        stats = processor.process_pending_files(conn, limit)
+        stats = processor.process_pending_files(conn, limit, reprocess_window_days)
         all_stats[table_name] = stats
         
         print(f"{table_name}: {stats['processed']} processed, {stats['errors']} errors")
@@ -227,6 +237,12 @@ def main():
         action='store_true',
         help='Disable logging to file'
     )
+    parser.add_argument(
+        '--reprocess-window-days',
+        type=int,
+        default=30,
+        help='Reprocessing window in days (default: 30, 0 = unlimited)'
+    )
     
     args = parser.parse_args()
     
@@ -250,6 +266,10 @@ def main():
     
     if args.limit:
         print(f"Limit: {args.limit} files per table")
+    if args.reprocess_window_days == 0:
+        print("Reprocessing window: unlimited")
+    else:
+        print(f"Reprocessing window: last {args.reprocess_window_days} days")
     
     start_time = datetime.now()
     discovery_stats = {}
@@ -261,11 +281,11 @@ def main():
         
         # Phase 1: Discovery
         if not args.process_only:
-            discovery_stats = run_discovery(conn)
+            discovery_stats = run_discovery(conn, args.reprocess_window_days)
         
         # Phase 2: Processing
         if not args.discover_only:
-            processing_stats = run_processing(conn, tables, args.limit)
+            processing_stats = run_processing(conn, tables, args.limit, args.reprocess_window_days)
     
     # Print summary
     print_summary(discovery_stats, processing_stats)

--- a/netflow-db/protocol_db.py
+++ b/netflow-db/protocol_db.py
@@ -283,7 +283,11 @@ def process_day_worker(day_info: tuple) -> dict:
     }
 
 
-def process_pending_files(conn: sqlite3.Connection, limit: int = None) -> dict:
+def process_pending_files(
+    conn: sqlite3.Connection,
+    limit: int = None,
+    reprocess_window_days: int = 30
+) -> dict:
     """
     Process all pending files for the protocol_stats table.
     Uses day-parallel processing where each worker handles a complete day.
@@ -291,9 +295,14 @@ def process_pending_files(conn: sqlite3.Connection, limit: int = None) -> dict:
     init_protocol_stats_table(conn)
     
     # Handle stale days - reset days that have new files mixed with already-processed files
-    handle_stale_days(conn, 'protocol_stats')
+    handle_stale_days(conn, 'protocol_stats', reprocess_window_days)
     
-    pending = get_files_needing_processing(conn, 'protocol_stats', limit)
+    pending = get_files_needing_processing(
+        conn,
+        'protocol_stats',
+        limit,
+        reprocess_window_days=reprocess_window_days,
+    )
     stats = {'processed': 0, 'errors': 0, 'aggregates': 0, 'days': 0}
     
     if not pending:

--- a/netflow-db/spectrum_db.py
+++ b/netflow-db/spectrum_db.py
@@ -363,7 +363,11 @@ def process_day_worker(day_info: tuple) -> dict:
     }
 
 
-def process_pending_files(conn: sqlite3.Connection, limit: int = None) -> dict:
+def process_pending_files(
+    conn: sqlite3.Connection,
+    limit: int = None,
+    reprocess_window_days: int = 30
+) -> dict:
     """
     Process all pending files for the spectrum_stats table.
     Uses day-parallel processing where each worker handles a complete day.
@@ -371,9 +375,14 @@ def process_pending_files(conn: sqlite3.Connection, limit: int = None) -> dict:
     init_spectrum_stats_table(conn)
     
     # Handle stale days - reset days that have new files mixed with already-processed files
-    handle_stale_days(conn, 'spectrum_stats')
+    handle_stale_days(conn, 'spectrum_stats', reprocess_window_days)
     
-    pending = get_files_needing_processing(conn, 'spectrum_stats', limit)
+    pending = get_files_needing_processing(
+        conn,
+        'spectrum_stats',
+        limit,
+        reprocess_window_days=reprocess_window_days,
+    )
     stats = {'processed': 0, 'errors': 0, 'aggregates': 0, 'days': 0}
     
     if not pending:

--- a/netflow-db/structure_db.py
+++ b/netflow-db/structure_db.py
@@ -364,7 +364,11 @@ def process_day_worker(day_info: tuple) -> dict:
     }
 
 
-def process_pending_files(conn: sqlite3.Connection, limit: int = None) -> dict:
+def process_pending_files(
+    conn: sqlite3.Connection,
+    limit: int = None,
+    reprocess_window_days: int = 30
+) -> dict:
     """
     Process all pending files for the structure_stats table.
     Uses day-parallel processing where each worker handles a complete day.
@@ -372,9 +376,14 @@ def process_pending_files(conn: sqlite3.Connection, limit: int = None) -> dict:
     init_structure_stats_table(conn)
     
     # Handle stale days - reset days that have new files mixed with already-processed files
-    handle_stale_days(conn, 'structure_stats')
+    handle_stale_days(conn, 'structure_stats', reprocess_window_days)
     
-    pending = get_files_needing_processing(conn, 'structure_stats', limit)
+    pending = get_files_needing_processing(
+        conn,
+        'structure_stats',
+        limit,
+        reprocess_window_days=reprocess_window_days,
+    )
     stats = {'processed': 0, 'errors': 0, 'aggregates': 0, 'days': 0}
     
     if not pending:

--- a/plans/reprocessing-window-plan.md
+++ b/plans/reprocessing-window-plan.md
@@ -1,0 +1,157 @@
+# Reprocessing Window Plan
+
+## Goal
+
+Align the pipeline with this operating model:
+
+- In normal operation, automatically check for missing data only within a configurable recent window.
+- Preserve enough historical state to reconstruct what days were complete, incomplete, or discovered late.
+- Allow operators to widen the window manually when upstream upload delays exceed the default horizon.
+- Ensure aggregate tables are always recomputed consistently when any file for a day is reprocessed.
+
+## Desired Behavior
+
+### Normal mode
+
+- The pipeline uses a default reprocessing window of 30 days.
+- Missing-file discovery and automatic stale-day reopening are limited to that window.
+- Synthetic gap placeholders older than the active window are preserved for historical visibility, but are not automatically processed.
+- Files older than the active window are left untouched in that run.
+
+### Recovery mode
+
+- Operators can widen the active reprocessing horizon with a CLI flag.
+- Example uses:
+  - default cron behavior: `python pipeline.py`
+  - delayed upload recovery: `python pipeline.py --reprocess-window-days 90`
+  - full historical reconciliation: `python pipeline.py --reprocess-window-days 0`
+- A value of `0` means no window limit.
+- Widening the window is what allows older stale aggregate days to be reopened and rebuilt.
+- A practical operating model is weekly 30-day runs plus a monthly wider reconciliation run, such as 180 days.
+
+### Processing model
+
+- `flow_stats` can be safely reprocessed at the file level.
+- `ip_stats`, `protocol_stats`, `spectrum_stats`, and `structure_stats` must be reprocessed at the day level.
+- If any file in a `(router, day)` changes state in an aggregate table, all aggregates for that day must be rebuilt from the full day.
+
+## Why This Change Is Needed
+
+The current code limits stale-day reset to the last 30 days, but older synthetic gap rows can still remain pending. That creates two problems:
+
+1. The system still checks older historical missing data, which conflicts with the intended default behavior.
+2. Aggregate tables can become inconsistent if an old file is processed without reopening the full day.
+
+For aggregate tables, the correct unit of recomputation is the entire day:
+
+- a changed 5-minute file affects its `5m` bucket
+- that also affects the containing `30m` bucket
+- that affects the containing `1h` bucket
+- that affects the `1d` bucket for the day
+
+Therefore, for aggregate tables, reprocessing any file in a day means reopening and recomputing the full day.
+
+## Implementation Plan
+
+### 1. Add a configurable window to the CLI
+
+Update `netflow-db/pipeline.py` to accept:
+
+- `--reprocess-window-days N`
+
+Behavior:
+
+- default: `30`
+- `0`: unlimited historical window
+
+This value should be threaded into discovery and all processors.
+
+### 2. Centralize cutoff calculation
+
+Add a shared helper in `netflow-db/discovery.py` to calculate the active cutoff timestamp.
+
+Requirements:
+
+- one implementation of window logic
+- used by both gap handling and stale-day reset logic
+- supports unlimited mode when the CLI passes `0`
+
+This avoids hardcoding `30` in multiple places.
+
+### 3. Preserve historical placeholder state
+
+Do not delete historical `file_exists = 0` rows from `processed_files`.
+
+Reason:
+
+- those rows are the durable record of expected-but-missing data
+- they allow reconstruction of whether a day was complete or incomplete at discovery time
+- they support later manual recovery if uploads arrive after the default horizon
+- they support scheduled wider-window reconciliation runs
+
+### 4. Restrict automatic gap processing to the active window
+
+Update `get_files_needing_processing()` in `netflow-db/discovery.py` so that:
+
+- files are only automatically eligible when within the active window
+- synthetic gap placeholders older than the active window remain stored, but inert
+- real files older than the active window are deferred until a wider-window run
+
+This enforces the intended default behavior without losing historical state.
+
+### 5. Apply the same window to stale-day reopening
+
+Update `handle_stale_days()` in `netflow-db/discovery.py` to use the configurable window instead of a fixed 30-day cutoff.
+
+Behavior:
+
+- normal mode reopens stale days only inside the default window
+- manual recovery mode can reopen older days by widening the window
+- unlimited mode can fully reconcile all history
+
+### 6. Make aggregate tables explicitly day-level
+
+For `ip_stats`, `protocol_stats`, `spectrum_stats`, and `structure_stats`, enforce this rule:
+
+- if any file in a `(router, day)` needs reprocessing, the processor must reopen and recompute the full day for that table before writing aggregates
+
+This should be treated as a core invariant, not an incidental side effect.
+
+Implication:
+
+- the day worker must operate on a complete reopened day, not just the currently pending subset, whenever aggregates are being rebuilt
+
+### 7. Keep `flow_stats` file-level
+
+`flow_stats` has no higher-level day aggregates in the current model, so file-level processing remains acceptable.
+
+No day-level reopening requirement is needed for `flow_stats` unless that table later gains aggregate derivations.
+
+### 8. Verify recovery workflows
+
+After implementation, validate these cases:
+
+1. A missing synthetic gap within the last 30 days is detected and processed automatically.
+2. A synthetic gap older than 30 days remains recorded but is not automatically processed.
+3. A late real file older than 30 days is deferred until a wider-window run.
+4. Widening the window reopens affected aggregate-table days and rebuilds them fully.
+5. Unlimited mode can reconcile all stale historical days.
+
+## Policy Decision Captured Here
+
+The system should distinguish between:
+
+- automatic recent-data maintenance
+- manual historical recovery
+
+Default automation should stay bounded. Historical recovery should be explicit and operator-driven.
+
+## Summary
+
+The target design is:
+
+- keep the default 30-day operational window
+- preserve historical missing-data state in the database
+- expose a CLI override for delayed-upload recovery
+- use the selected window as the single control knob for automatic processing in that run
+- treat aggregate-table reprocessing as a day-level operation whenever any file in that day changes


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a configurable `--reprocess-window-days` CLI flag (default 30, `0` = unlimited) that gates which files and days the pipeline automatically revisits, replacing a previously hard-coded 30-day constant in `handle_stale_days`. The change centralises cutoff logic in a new `get_reprocess_cutoff_dt` helper in `discovery.py` and threads the parameter through all five processor modules and both pipeline phases.

**Key issues found:**
- **Real files blocked by reprocessing window** — Both `get_files_needing_processing` and `get_pending_files` apply the window cutoff to all rows, including real files (`file_exists = 1`). The design spec (`plans/reprocessing-window-plan.md`) explicitly requires that only synthetic gap placeholders (`file_exists = 0`) be gated by the window, while real files must always remain eligible. A late-arriving upload older than 30 days will be silently excluded from processing under default settings.
- **Full table scan before Python-side filtering** — The SQL queries no longer include any timestamp constraint, fetching the entire unprocessed backlog into memory before applying the window filter and limit in Python. For databases with large historical records this will degrade pipeline performance; adding `AND (file_exists = 1 OR timestamp >= ?)` directly to the SQL when the window is not unlimited would be more efficient.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge as-is — real late-arriving files will be silently skipped under default settings, contradicting the stated design and recovery workflow.
- The overall structure is sound and the propagation of the new parameter through the pipeline is clean. However, there is a meaningful logic bug in the two core file-selection functions in discovery.py: the reprocessing window is applied to real files as well as gap placeholders, which contradicts the explicit design requirement that real files always remain eligible. This would silently prevent late-arriving uploads older than 30 days from being ingested, making the feature incomplete relative to its own specification.
- netflow-db/discovery.py — specifically get_pending_files (line 287) and get_files_needing_processing (line 370) need the cutoff guard conditioned on `file_exists = 0` only.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| netflow-db/discovery.py | Core logic file with two bugs: both get_pending_files and get_files_needing_processing apply the reprocessing window cutoff to real files (file_exists=1) as well as synthetic gap placeholders, contradicting the design spec which requires real files to always be eligible. Also fetches all unprocessed rows into memory before Python-side filtering, which will be slow at scale. |
| netflow-db/pipeline.py | Clean orchestration layer; correctly threads reprocess_window_days through run_discovery and run_processing, and adds the CLI argument with sensible defaults. |
| netflow-db/flow_db.py | Correctly propagates reprocess_window_days to handle_stale_days and get_files_needing_processing; no issues. |
| netflow-db/ip_db.py | Correctly propagates reprocess_window_days; no issues. |
| netflow-db/protocol_db.py | Correctly propagates reprocess_window_days; no issues. |
| netflow-db/spectrum_db.py | Correctly propagates reprocess_window_days; no issues. |
| netflow-db/structure_db.py | Correctly propagates reprocess_window_days; no issues. |
| docs/pipeline-usage.md | New documentation accurately describes the --reprocess-window-days flag and its behavior; no issues. |
| plans/reprocessing-window-plan.md | Design document; clearly captures the intent that real files must always remain eligible regardless of window, which the implementation does not fully honour. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CLI as pipeline.py (CLI)
    participant D as discovery.py
    participant P as *_db.py (processors)

    CLI->>CLI: parse --reprocess-window-days (default 30)
    CLI->>D: run_discovery(conn, reprocess_window_days)
    D->>D: get_reprocess_cutoff_dt(reprocess_window_days)
    D->>D: sync_processed_files_table(conn, reprocess_window_days)
    note over D: Gap scan starts at max(router_start, cutoff_dt)
    D->>D: get_pending_files(conn, reprocess_window_days)
    note over D: ⚠ Cutoff applied to ALL rows incl. file_exists=1

    CLI->>P: run_processing(conn, tables, limit, reprocess_window_days)
    P->>D: handle_stale_days(conn, table, reprocess_window_days)
    D->>D: get_reprocess_cutoff_dt(reprocess_window_days)
    note over D: Stale days outside window are skipped
    P->>D: get_files_needing_processing(conn, table, limit, reprocess_window_days)
    D->>D: get_reprocess_cutoff_dt(reprocess_window_days)
    note over D: ⚠ Cutoff applied to ALL rows incl. file_exists=1
    P->>P: process files / rebuild day aggregates
```

<sub>Last reviewed commit: 4393ae4</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->