### PR TITLE
fix(env): use repo-level env as source of truth

### DIFF
--- a/docs/pipeline-usage.md
+++ b/docs/pipeline-usage.md
@@ -9,10 +9,19 @@ It does two things:
 
 ## Normal run
 
-From the repo root:
+The repo-level `.env` is the single source of truth.
+
+The pipeline resolves that file relative to the script location, so you can run it either from the repo root or from `netflow-db/`.
 
 ```bash
 python netflow-db/pipeline.py
+```
+
+or
+
+```bash
+cd netflow-db
+python pipeline.py
 ```
 
 That uses the default reprocessing window of 30 days.

--- a/netflow-db/common.py
+++ b/netflow-db/common.py
@@ -13,18 +13,22 @@ from typing import Optional
 from contextlib import contextmanager
 
 
-def load_env_file(env_path: str = '../.env') -> None:
+DEFAULT_ENV_PATH = Path(__file__).resolve().parent.parent / '.env'
+
+
+def load_env_file(env_path: Optional[str] = None) -> None:
     """
     Load environment variables from a dotenv-style file into os.environ.
     
-    Reads the file at env_path (default '../.env'), ignoring empty lines and lines
-    starting with '#'. Each non-comment line containing '=' is split on the first
-    '=' and the left/right parts are stripped and set as KEY=VALUE in os.environ.
+    Reads the file at env_path (default repo-level '.env'), ignoring empty lines
+    and lines starting with '#'. Each non-comment line containing '=' is split on
+    the first '=' and the left/right parts are stripped and set as KEY=VALUE in
+    os.environ.
     
     If the file does not exist, prints an error message and exits the process with
     status code 1.
     """
-    env_file = Path(env_path)
+    env_file = DEFAULT_ENV_PATH if env_path is None else Path(env_path).expanduser()
     if env_file.exists():
         with open(env_file, 'r') as f:
             for line in f:
@@ -33,7 +37,7 @@ def load_env_file(env_path: str = '../.env') -> None:
                     key, value = line.split('=', 1)
                     os.environ[key.strip()] = value.strip()
     else:
-        print(f"ERROR: Environment file '{env_path}' not found!")
+        print(f"ERROR: Environment file '{env_file}' not found!")
         print("Please copy .env.example to .env and configure your settings.")
         sys.exit(1)
 

--- a/netflow-db/depr_ip_db.py
+++ b/netflow-db/depr_ip_db.py
@@ -8,19 +8,23 @@ from pathlib import Path
 from datetime import datetime, timedelta
 from multiprocessing import Pool
 
+DEFAULT_ENV_PATH = Path(__file__).resolve().parent.parent / '.env'
+
+
 # Load environment variables from .env file
-def load_env_file(env_path='../.env'):
+def load_env_file(env_path=None):
     """
     Load environment variables from a dotenv-style file into os.environ.
     
-    Reads the file at env_path (default '../.env'), ignoring empty lines and lines
-    starting with '#'. Each non-comment line containing '=' is split on the first
-    '=' and the left/right parts are stripped and set as KEY=VALUE in os.environ.
+    Reads the file at env_path (default repo-level '.env'), ignoring empty lines
+    and lines starting with '#'. Each non-comment line containing '=' is split
+    on the first '=' and the left/right parts are stripped and set as KEY=VALUE
+    in os.environ.
     
     If the file does not exist, prints an error message and exits the process with
     status code 1.
     """
-    env_file = Path(env_path)
+    env_file = DEFAULT_ENV_PATH if env_path is None else Path(env_path).expanduser()
     if env_file.exists():
         with open(env_file, 'r') as f:
             for line in f:
@@ -29,7 +33,7 @@ def load_env_file(env_path='../.env'):
                     key, value = line.split('=', 1)
                     os.environ[key.strip()] = value.strip()
     else:
-        print(f"ERROR: Environment file '{env_path}' not found!")
+        print(f"ERROR: Environment file '{env_file}' not found!")
         print("Please copy .env.example to .env and configure your settings.")
         sys.exit(1)
 

--- a/netflow-db/ip_time.py
+++ b/netflow-db/ip_time.py
@@ -5,19 +5,23 @@ from pathlib import Path
 from datetime import datetime, timedelta
 from multiprocessing import Pool
 
+DEFAULT_ENV_PATH = Path(__file__).resolve().parent.parent / '.env'
+
+
 # Load environment variables from .env file
-def load_env_file(env_path='../.env'):
+def load_env_file(env_path=None):
     """
     Load environment variables from a dotenv-style file into os.environ.
     
-    Reads the file at env_path (default '../.env'), ignoring empty lines and lines
-    starting with '#'. Each non-comment line containing '=' is split on the first
-    '=' and the left/right parts are stripped and set as KEY=VALUE in os.environ.
+    Reads the file at env_path (default repo-level '.env'), ignoring empty lines
+    and lines starting with '#'. Each non-comment line containing '=' is split
+    on the first '=' and the left/right parts are stripped and set as KEY=VALUE
+    in os.environ.
     
     If the file does not exist, prints an error message and exits the process with
     status code 1.
     """
-    env_file = Path(env_path)
+    env_file = DEFAULT_ENV_PATH if env_path is None else Path(env_path).expanduser()
     if env_file.exists():
         with open(env_file, 'r') as f:
             for line in f:
@@ -26,7 +30,7 @@ def load_env_file(env_path='../.env'):
                     key, value = line.split('=', 1)
                     os.environ[key.strip()] = value.strip()
     else:
-        print(f"ERROR: Environment file '{env_path}' not found!")
+        print(f"ERROR: Environment file '{env_file}' not found!")
         print("Please copy .env.example to .env and configure your settings.")
         sys.exit(1)
 

--- a/netflow-db/verify_ip_uniqueness.py
+++ b/netflow-db/verify_ip_uniqueness.py
@@ -21,12 +21,14 @@ from itertools import combinations
 from pathlib import Path
 from typing import Dict, Iterable, List, Optional, Set, Tuple
 
+DEFAULT_ENV_PATH = Path(__file__).resolve().parent.parent / ".env"
+
 
 def load_env_file(env_path: str) -> None:
     """Populate os.environ with key/value pairs from a dotenv-style file."""
-    env_file = Path(env_path)
+    env_file = Path(env_path).expanduser()
     if not env_file.exists():
-        print(f"ERROR: Environment file '{env_path}' not found.", file=sys.stderr)
+        print(f"ERROR: Environment file '{env_file}' not found.", file=sys.stderr)
         sys.exit(1)
 
     with env_file.open("r", encoding="utf-8") as handle:
@@ -294,8 +296,8 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--env-path",
-        default="../.env",
-        help="Path to the environment file (defaults to ../.env).",
+        default=str(DEFAULT_ENV_PATH),
+        help="Path to the environment file (defaults to the repo-level .env).",
     )
     parser.add_argument(
         "--timeout",
@@ -379,4 +381,3 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
-


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes environment file resolution across all NetFlow pipeline scripts by replacing the CWD-relative default `'../.env'` with an absolute path anchored to each script's own location via `Path(__file__).resolve().parent.parent / '.env'`. This makes scripts runnable from any working directory (repo root or `netflow-db/`) without path resolution failures.

Key changes:
- `common.py`, `depr_ip_db.py`, `ip_time.py`: `load_env_file` now accepts `Optional[str]` (defaulting to `None`), and resolves to `DEFAULT_ENV_PATH` when no path is supplied. The error message now prints the fully-resolved `Path` object for easier debugging.
- `verify_ip_uniqueness.py`: Adds `DEFAULT_ENV_PATH` and wires it as the argparse default for `--env-path`. The error message prints the original `env_path` string rather than the resolved `env_file`, which is a minor inconsistency compared to the other files.
- `docs/pipeline-usage.md`: Updated to document that scripts work correctly from both `netflow-db/` and the repo root.
- The `load_env_file` implementation remains duplicated across three files (pre-existing design), which means future changes to this logic will need to be applied in multiple places.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge; the core fix is correct and well-applied across all affected files.
- The path-resolution logic is sound and consistent. One minor inconsistency exists in `verify_ip_uniqueness.py`'s error message (printing the raw string instead of the resolved path), which is a cosmetic issue worth tidying up. No functional regressions introduced.
- netflow-db/verify_ip_uniqueness.py — minor error-message inconsistency worth tidying up.

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Script
    participant load_env_file
    participant FileSystem
    participant ProcessEnv

    Script->>load_env_file: invoke with optional path
    alt no path provided
        load_env_file->>load_env_file: use DEFAULT_ENV_PATH via __file__
    else custom path provided
        load_env_file->>load_env_file: apply expanduser to path
    end
    load_env_file->>FileSystem: check if dotenv file exists
    alt file found
        FileSystem-->>load_env_file: open handle
        load_env_file->>ProcessEnv: populate config entries
        load_env_file-->>Script: return successfully
    else file not found
        load_env_file-->>Script: print resolved path error, exit 1
    end
```

<sub>Last reviewed commit: 5f8adff</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->