### PR TITLE
feat(discovery): add filesystem discovery window

### DIFF
--- a/docs/pipeline-usage.md
+++ b/docs/pipeline-usage.md
@@ -7,6 +7,13 @@ It does two things:
 - discovers files and recent gaps
 - processes pending data into the stats tables
 
+There are two separate windows:
+
+- `--discovery-window-days`: how far back the filesystem scan looks for real files
+- `--reprocess-window-days`: how far back the pipeline is willing to act on discovered data in that run
+
+If you do not pass `--discovery-window-days`, it defaults to the same value as `--reprocess-window-days`.
+
 ## Normal run
 
 The repo-level `.env` is the single source of truth.
@@ -56,6 +63,12 @@ Limit how much work is done per table:
 
 ```bash
 python netflow-db/pipeline.py --limit 500
+```
+
+Use a separate discovery window:
+
+```bash
+python netflow-db/pipeline.py --discovery-window-days 30 --reprocess-window-days 14
 ```
 
 Disable log-file output:

--- a/netflow-db/discovery.py
+++ b/netflow-db/discovery.py
@@ -22,45 +22,53 @@ from common import (
 )
 
 
-def scan_filesystem() -> Iterator[tuple[str, str, datetime]]:
+def iter_scan_days(discovery_window_days: int = 0) -> Iterator[datetime]:
     """
-    Walk the NetFlow directory tree and yield all nfcapd files.
-    
+    Yield day-start datetimes to inspect during filesystem discovery.
+
+    Args:
+        discovery_window_days: Number of calendar days to inspect. ``0`` means
+            unlimited from ``DATA_START_DATE`` through today.
+    """
+    start_dt = get_discovery_start_dt(discovery_window_days)
+    end_dt = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+    current = start_dt
+
+    while current <= end_dt:
+        yield current
+        current += timedelta(days=1)
+
+
+def scan_filesystem(discovery_window_days: int = 0) -> Iterator[tuple[str, str, datetime]]:
+    """
+    Scan the filesystem within the configured discovery window and yield nfcapd files.
+
     Yields:
         Tuples of (file_path, router, timestamp) for each discovered file
     """
     base_path = Path(NETFLOW_DATA_PATH)
-    
+    scan_days = list(iter_scan_days(discovery_window_days))
+
     for router in AVAILABLE_ROUTERS:
         router_path = base_path / router
         if not router_path.exists():
             print(f"Warning: Router path does not exist: {router_path}")
             continue
-        
-        # Walk through year/month/day directories
-        for year_dir in sorted(router_path.iterdir()):
-            if not year_dir.is_dir() or not year_dir.name.isdigit():
+
+        for day_start in scan_days:
+            day_dir = router_path / day_start.strftime('%Y') / day_start.strftime('%m') / day_start.strftime('%d')
+            if not day_dir.is_dir():
                 continue
-                
-            for month_dir in sorted(year_dir.iterdir()):
-                if not month_dir.is_dir() or not month_dir.name.isdigit():
-                    continue
-                    
-                for day_dir in sorted(month_dir.iterdir()):
-                    if not day_dir.is_dir() or not day_dir.name.isdigit():
+
+            for file_path in sorted(day_dir.glob('nfcapd.*')):
+                try:
+                    router_parsed, timestamp = parse_file_path(str(file_path))
+                    if timestamp < DATA_START_DATE:
                         continue
-                    
-                    # Find all nfcapd files in this day directory
-                    for file_path in sorted(day_dir.glob('nfcapd.*')):
-                        try:
-                            router_parsed, timestamp = parse_file_path(str(file_path))
-                            # Skip files before DATA_START_DATE
-                            if timestamp < DATA_START_DATE:
-                                continue
-                            yield str(file_path), router_parsed, timestamp
-                        except ValueError as e:
-                            print(f"Warning: Could not parse file {file_path}: {e}")
-                            continue
+                    yield str(file_path), router_parsed, timestamp
+                except ValueError as e:
+                    print(f"Warning: Could not parse file {file_path}: {e}")
+                    continue
 
 
 def compute_data_horizon(conn: sqlite3.Connection) -> datetime:
@@ -154,10 +162,31 @@ def get_reprocess_cutoff_dt(reprocess_window_days: int = 30) -> Optional[datetim
     )
 
 
+def get_discovery_start_dt(discovery_window_days: int = 0) -> datetime:
+    """
+    Return the day-start lower bound for filesystem discovery.
+
+    Args:
+        discovery_window_days: Number of calendar days to inspect. ``0`` means
+            unlimited from ``DATA_START_DATE``.
+    """
+    if discovery_window_days == 0:
+        return DATA_START_DATE.replace(hour=0, minute=0, second=0, microsecond=0)
+    if discovery_window_days < 0:
+        raise ValueError("discovery_window_days must be >= 0")
+
+    cutoff_dt = (
+        datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+        - timedelta(days=discovery_window_days)
+    )
+    return max(DATA_START_DATE.replace(hour=0, minute=0, second=0, microsecond=0), cutoff_dt)
+
+
 def sync_processed_files_table(
     conn: sqlite3.Connection,
     include_gaps: bool = True,
-    reprocess_window_days: int = 30
+    reprocess_window_days: int = 30,
+    discovery_window_days: int = 0
 ) -> dict:
     """
     Synchronize the processed_files table with the filesystem.
@@ -171,6 +200,8 @@ def sync_processed_files_table(
         conn: Database connection
         include_gaps: If True, also insert gap placeholders (file_exists=0)
         reprocess_window_days: Gap detection window in days. ``0`` means unlimited.
+        discovery_window_days: Filesystem discovery window in days. ``0`` means
+            unlimited from ``DATA_START_DATE``.
         
     Returns:
         Dictionary with counts: {'discovered': N, 'new_files': N, 'gaps': N}
@@ -182,7 +213,7 @@ def sync_processed_files_table(
     
     # Phase 1: Insert all discovered files
     print("Scanning filesystem for NetFlow files...")
-    for file_path, router, timestamp in scan_filesystem():
+    for file_path, router, timestamp in scan_filesystem(discovery_window_days):
         stats['discovered'] += 1
         
         # Insert or ignore if already exists

--- a/netflow-db/pipeline.py
+++ b/netflow-db/pipeline.py
@@ -10,7 +10,7 @@ This is the main entry point for cron-based processing. It orchestrates:
 
 Usage:
     python pipeline.py [--discover-only] [--process-only] [--limit N] [--tables TABLE1,TABLE2]
-                       [--reprocess-window-days N]
+                       [--reprocess-window-days N] [--discovery-window-days N]
     
 Options:
     --discover-only   Only run discovery phase, skip processing
@@ -20,6 +20,9 @@ Options:
                       Valid: flow_stats,ip_stats,protocol_stats,spectrum_stats,structure_stats
     --reprocess-window-days N
                       Reprocessing window in days (default: 30, 0 = unlimited)
+    --discovery-window-days N
+                      Discovery scan window in days (default: matches reprocessing window,
+                      0 = unlimited)
 """
 
 import argparse
@@ -87,7 +90,11 @@ def setup_logging(log_dir: Path = None):
     return log_file
 
 
-def run_discovery(conn: sqlite3.Connection, reprocess_window_days: int = 30) -> dict:
+def run_discovery(
+    conn: sqlite3.Connection,
+    reprocess_window_days: int = 30,
+    discovery_window_days: int = 30
+) -> dict:
     """
     Run the file discovery phase.
     
@@ -96,6 +103,7 @@ def run_discovery(conn: sqlite3.Connection, reprocess_window_days: int = 30) -> 
     Args:
         conn: Database connection
         reprocess_window_days: Reprocessing window in days. ``0`` means unlimited.
+        discovery_window_days: Discovery scan window in days. ``0`` means unlimited.
         
     Returns:
         Discovery statistics
@@ -108,6 +116,7 @@ def run_discovery(conn: sqlite3.Connection, reprocess_window_days: int = 30) -> 
         conn,
         include_gaps=True,
         reprocess_window_days=reprocess_window_days,
+        discovery_window_days=discovery_window_days,
     )
     
     horizon = compute_data_horizon(conn)
@@ -243,8 +252,19 @@ def main():
         default=30,
         help='Reprocessing window in days (default: 30, 0 = unlimited)'
     )
+    parser.add_argument(
+        '--discovery-window-days',
+        type=int,
+        default=None,
+        help='Discovery scan window in days (default: matches reprocessing window, 0 = unlimited)'
+    )
     
     args = parser.parse_args()
+    discovery_window_days = (
+        args.reprocess_window_days
+        if args.discovery_window_days is None
+        else args.discovery_window_days
+    )
     
     # Setup logging
     if not args.no_log:
@@ -270,6 +290,10 @@ def main():
         print("Reprocessing window: unlimited")
     else:
         print(f"Reprocessing window: last {args.reprocess_window_days} days")
+    if discovery_window_days == 0:
+        print("Discovery window: unlimited")
+    else:
+        print(f"Discovery window: last {discovery_window_days} days")
     
     start_time = datetime.now()
     discovery_stats = {}
@@ -281,7 +305,11 @@ def main():
         
         # Phase 1: Discovery
         if not args.process_only:
-            discovery_stats = run_discovery(conn, args.reprocess_window_days)
+            discovery_stats = run_discovery(
+                conn,
+                args.reprocess_window_days,
+                discovery_window_days,
+            )
         
         # Phase 2: Processing
         if not args.discover_only:

--- a/plans/discovery-window-optimization-plan.md
+++ b/plans/discovery-window-optimization-plan.md
@@ -1,0 +1,228 @@
+# Discovery Window Optimization Plan
+
+## Goal
+
+Reduce filesystem discovery cost by scanning only a bounded date window instead of walking the full historical tree on every run.
+
+The file layout under `NETFLOW_DATA_PATH` is assumed to be stable and predictable:
+
+- `router/YYYY/MM/DD/nfcapd.YYYYMMDDHHMM`
+
+That means discovery can jump directly to expected day directories instead of recursively traversing all years, months, and days.
+
+## Desired Outcome
+
+- Normal runs only inspect recent day directories.
+- Wider reconciliation runs can inspect older day directories when needed.
+- Full historical scan remains available as an explicit override.
+- Processing semantics stay the same; this is primarily a discovery optimization.
+
+## Proposed Model
+
+Introduce a discovery window that is distinct from the reprocessing window.
+
+- `reprocess_window_days` controls which discovered data the pipeline is willing to act on during that run.
+- `discovery_window_days` controls how far back the filesystem scan looks for real files.
+
+These two windows can be set independently, but the default behavior should be simple and predictable.
+
+## Time Semantics
+
+Both windows should use the same day-based definition:
+
+- compute from local midnight, not from the current wall-clock timestamp
+- clamp to `DATA_START_DATE`
+- treat `0` as unlimited
+
+This avoids off-by-one behavior at day boundaries and makes the system easier to reason about operationally.
+
+## Edge Cases To Account For
+
+### 1. Boundary-day mismatches
+
+Do not mix:
+
+- "last N calendar days from local midnight"
+- with "last N x 24 hours from right now"
+
+The implementation should use calendar-day windows consistently for both discovery and reprocessing.
+
+### 2. Discovery may need a slightly wider horizon than processing
+
+Using the same default value for both windows is reasonable, but discovery and reprocessing are not identical concepts.
+
+Example:
+
+- a late file arrives for 15 days ago
+- weekly run uses `14`
+- if discovery also uses `14`, that file will not be discovered during that run
+
+That may be acceptable operationally, but it should be an explicit consequence of the chosen window, not an accidental artifact.
+
+The plan should therefore:
+
+- default `discovery_window_days` to `reprocess_window_days`
+- keep it configurable as a separate flag
+- allow a future cushion if needed, such as discovery being slightly wider than reprocessing
+
+### 3. Complete-day behavior around the edge of the window
+
+A newly discovered file can still belong to a day that is not yet considered complete.
+
+That is expected.
+
+Discovery and processing should remain decoupled enough that:
+
+- a file can be discovered in one run
+- but only processed once its day is complete and within the active reprocessing window
+
+### 4. Missed wider reconciliation runs
+
+If the operational model relies on:
+
+- frequent narrow runs
+- occasional wider runs
+
+then skipping a wider run means older delayed files will stay undiscovered longer.
+
+This is acceptable if intentional, but it should be documented as part of the operating model.
+
+## CLI Changes
+
+Add a new pipeline flag:
+
+- `--discovery-window-days N`
+
+Behavior:
+
+- default: if unspecified, use the same value as `--reprocess-window-days`
+- `0`: unlimited discovery scan
+
+Examples:
+
+- weekly run: `python pipeline.py --reprocess-window-days 14 --discovery-window-days 14`
+- monthly run: `python pipeline.py --reprocess-window-days 90 --discovery-window-days 90`
+- full historical audit: `python pipeline.py --discovery-window-days 0 --reprocess-window-days 0`
+
+## Implementation Plan
+
+### 1. Add discovery-window plumbing to the pipeline
+
+Update `netflow-db/pipeline.py` to accept and print:
+
+- `--discovery-window-days N`
+
+Thread that value into discovery functions the same way `reprocess_window_days` is threaded today.
+
+Default behavior:
+
+- if the user does not pass `--discovery-window-days`, set it equal to `reprocess_window_days`
+
+That gives one intuitive control by default, while still allowing them to diverge later if needed.
+
+### 2. Add a shared helper for the discovery start date
+
+In `netflow-db/discovery.py`, add a helper that computes the discovery lower bound:
+
+- `None` when unlimited
+- otherwise `today_midnight - discovery_window_days`
+- always clamped to `DATA_START_DATE`
+
+This helper should be separate from the reprocessing cutoff helper because the semantics are different.
+
+### 3. Replace recursive tree walking with direct date-directory enumeration
+
+Refactor `scan_filesystem()` so it no longer walks every year/month/day directory under each router.
+
+Instead:
+
+- compute the inclusive set of days in the discovery window
+- for each router
+- for each day in that range
+  - construct `NETFLOW_DATA_PATH/router/YYYY/MM/DD`
+  - if the directory exists, glob `nfcapd.*` within it
+  - if it does not exist, skip it
+
+This should become the primary discovery path.
+
+### 4. Keep full historical discovery mode available
+
+When `discovery_window_days = 0`:
+
+- preserve current unbounded behavior
+- either via the old recursive scan implementation or by enumerating every day from `DATA_START_DATE` to today
+
+If performance and simplicity favor it, a direct day-enumeration loop from `DATA_START_DATE` to today is acceptable even in unlimited mode.
+
+### 5. Ensure discovery and gap detection remain compatible
+
+Real-file discovery and synthetic-gap detection should operate over compatible horizons.
+
+Recommended rule:
+
+- discovery only creates/updates real-file entries from within the discovery window
+- gap detection only checks within the reprocessing window
+
+This preserves the current processing semantics while making file discovery cheaper.
+
+If we later find we need gap detection to track a broader horizon than reprocessing, that can be added explicitly, but should not be mixed into this first optimization.
+
+### 6. Preserve historical state in the database
+
+Do not delete old `processed_files` entries.
+
+This optimization is about reducing filesystem traversal, not changing what historical state is retained.
+
+That means:
+
+- old real-file rows stay in the database
+- old synthetic-gap rows stay in the database
+- only the filesystem scan range becomes narrower
+
+### 7. Make defaults match operations
+
+Recommended operating pattern:
+
+- weekly runs: 14-day discovery + 14-day reprocessing
+- monthly runs: 90-day discovery + 90-day reprocessing
+
+This matches the current intended use:
+
+- regular recent updates
+- periodic fill-in of older late-arriving data
+
+The docs should explicitly note that if a wider reconciliation run is skipped, older delayed files outside the narrow window will remain undiscovered until the next wider run.
+
+### 8. Optional second phase: scan watermark per router
+
+After the date-window optimization lands, consider a follow-up improvement:
+
+- store last scanned day per router
+- on normal runs, scan from `min(window_start, last_scanned_day - overlap)` to today
+
+This is optional and should not be bundled into the first implementation.
+
+The first pass should stay simple and easy to reason about.
+
+## Validation Plan
+
+Validate these cases:
+
+1. A narrow discovery window only inspects recent day directories.
+2. A wider discovery window finds older late-arriving files correctly.
+3. Unlimited mode still discovers all historical files.
+4. Processing behavior remains unchanged for already-discovered rows.
+5. Boundary-day behavior is stable around local midnight.
+6. Weekly and monthly operational runs work as expected with their respective windows.
+
+## Recommendation
+
+Implement the first pass as:
+
+- `--discovery-window-days`
+- default to `reprocess_window_days` when unset
+- direct date-directory enumeration in `scan_filesystem()`
+- preserve `0` as unlimited mode
+- keep the two windows conceptually separate even if they share a default value
+
+That gives a meaningful discovery-speed improvement without changing the underlying pipeline model.


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a configurable `--discovery-window-days` flag that decouples filesystem discovery from the reprocessing window, replacing the previous full recursive directory tree-walk with direct date-directory enumeration. The change reduces unnecessary I/O on normal runs by scanning only a bounded window of day directories (`router/YYYY/MM/DD/`) while keeping unlimited historical mode available via `--discovery-window-days 0`.

Key changes:
- `iter_scan_days(discovery_window_days)` and `get_discovery_start_dt(discovery_window_days)` added to `discovery.py` to compute the bounded set of day directories to inspect.
- `scan_filesystem()` refactored from a recursive `iterdir()` walk to targeted `day_dir.glob('nfcapd.*')` calls per day in the window.
- `--discovery-window-days N` CLI flag added to `pipeline.py`; defaults to `reprocess_window_days` when not supplied.
- Both windows use consistent calendar-day semantics (local midnight) and clamp to `DATA_START_DATE`.

The core logic is sound and correct. One minor issue: the `sync_processed_files_table` docstring still claims to scan "all nfcapd files," which no longer reflects the bounded discovery window behavior.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge. The core logic is correct and well-tested, with proper parameter threading through the call stack.
- The refactoring from recursive tree-walk to bounded day-directory enumeration is sound. The two-window design (discovery and reprocessing) is correctly implemented with consistent semantics and proper clipping to `DATA_START_DATE`. All explicit parameter passing in `main()` ensures correct behavior. Only one minor issue remains: a docstring update to reflect bounded discovery behavior. This does not affect functionality.
- No files require special attention — the docstring issue in `netflow-db/discovery.py` is a straightforward one-line fix.

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([pipeline.py main]) --> B{--discovery-window-days<br/>provided?}
    B -- No --> C[discovery_window_days<br/>= reprocess_window_days]
    B -- Yes --> D[discovery_window_days<br/>= arg value]
    C --> E[run_discovery]
    D --> E
    E --> F[sync_processed_files_table<br/>discovery_window_days, reprocess_window_days]
    F --> G[scan_filesystem<br/>discovery_window_days]
    G --> H[get_discovery_start_dt]
    H --> I{discovery_window_days == 0?}
    I -- Yes<br/>unlimited --> J[start = DATA_START_DATE midnight]
    I -- No<br/>bounded --> K[start = today_midnight<br/>- N days<br/>clamped to DATA_START_DATE]
    J --> L[iter_scan_days<br/>yield each day → today]
    K --> L
    L --> M[for each router × each day<br/>build router/YYYY/MM/DD path]
    M --> N{day dir exists?}
    N -- No --> O[skip]
    N -- Yes --> P[glob nfcapd.* <br/>yield file_path, router, timestamp]
    P --> Q[(processed_files DB<br/>INSERT OR IGNORE)]
    F --> R[gap detection<br/>reprocess_window_days only]
    R --> Q
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `netflow-db/discovery.py`, line 195-196 ([link](https://github.com/flamboh/netflow-analysis/blob/5e8fe91c3e716e83ef1561c651db4a7a23c8a1a5/netflow-db/discovery.py#L195-L196)) 

   The function-level docstring still describes the scan as applying to **all** nfcapd files, but the function now respects a bounded `discovery_window_days` parameter. Update to reflect the new behavior:

</details>

<!-- /greptile_failed_comments -->

<sub>Last reviewed commit: 5e8fe91</sub>

<!-- /greptile_comment -->