### PR TITLE
feat(webapp): simplify file analysis headings

### DIFF
--- a/netflow-webapp/src/lib/components/charts/SingularitiesList.svelte
+++ b/netflow-webapp/src/lib/components/charts/SingularitiesList.svelte
@@ -14,13 +14,6 @@
 
 {#if data}
 	<div class="w-full space-y-4">
-		<div class="mb-2 text-sm text-gray-600">
-			<p>
-				Data Source: {data.metadata.dataSource} | Address Type: {data.metadata.addressType}
-			</p>
-			<p>Point Count: {data.metadata.pointCount}</p>
-		</div>
-
 		{#if topSingularities.length > 0}
 			<div class="rounded-lg border bg-green-50 p-4">
 				<h4 class="mb-2 font-semibold">Top Singularities (Most Anomalous)</h4>

--- a/netflow-webapp/src/lib/components/charts/SpectrumChart.svelte
+++ b/netflow-webapp/src/lib/components/charts/SpectrumChart.svelte
@@ -21,14 +21,6 @@
 
 	// Watch for data changes and create/update chart
 	$effect(() => {
-		console.log('SpectrumChart effect triggered', {
-			hasCanvas: !!chartCanvas,
-			hasData: !!data,
-			hasSpectrum: !!data?.spectrum,
-			dataLength: data?.spectrum?.length || 0,
-			router: data?.router
-		});
-
 		if (chartCanvas && data?.spectrum?.length > 0) {
 			if (chart) {
 				chart.destroy();
@@ -110,13 +102,6 @@
 					}
 				},
 				plugins: {
-					title: {
-						display: true,
-						text: `Spectrum - ${data.router} - ${data.filename}`,
-						font: {
-							size: 16
-						}
-					},
 					legend: {
 						display: true,
 						position: 'top' as const
@@ -152,11 +137,6 @@
 
 <div class="w-full">
 	<div class="mb-2 text-sm text-gray-600">
-		<p>
-			Data Source: {data.metadata.dataSource} | alpha Range: [{data.metadata.alphaRange.min.toFixed(
-				3
-			)}, {data.metadata.alphaRange.max.toFixed(3)}]
-		</p>
 		{#if data.metadata.uniqueIPCount && data.metadata.uniqueIPCount > 0}
 			<p class="text-xs font-medium text-green-600">
 				✓ Real NetFlow Data Analysis - {data.metadata.uniqueIPCount.toLocaleString()} unique IP addresses

--- a/netflow-webapp/src/lib/components/charts/StructureFunctionChart.svelte
+++ b/netflow-webapp/src/lib/components/charts/StructureFunctionChart.svelte
@@ -21,14 +21,6 @@
 
 	// Watch for data changes and create/update chart
 	$effect(() => {
-		console.log('StructureFunctionChart effect triggered', {
-			hasCanvas: !!chartCanvas,
-			hasData: !!data,
-			hasStructureFunction: !!data?.structureFunction,
-			dataLength: data?.structureFunction?.length || 0,
-			router: data?.router
-		});
-
 		if (chartCanvas && data?.structureFunction?.length > 0) {
 			if (chart) {
 				chart.destroy();
@@ -136,13 +128,6 @@
 					}
 				},
 				plugins: {
-					title: {
-						display: true,
-						text: `Structure Function - ${data.router} - ${data.filename}`,
-						font: {
-							size: 16
-						}
-					},
 					legend: {
 						display: true,
 						position: 'top' as const
@@ -185,20 +170,11 @@
 
 <div class="w-full">
 	<div class="mb-2 text-sm text-gray-600">
-		<p>
-			Data Source: {data.metadata.dataSource} | q Range: [{data.metadata.qRange.min.toFixed(1)}, {data.metadata.qRange.max.toFixed(
-				1
-			)}]
-		</p>
 		{#if data.metadata.uniqueIPCount && data.metadata.uniqueIPCount > 0}
 			<p class="text-xs font-medium text-green-600">
 				✓ Real NetFlow Data Analysis - {data.metadata.uniqueIPCount.toLocaleString()} unique IP addresses
 				analyzed
 			</p>
-			<!-- {:else if data.metadata.uniqueIPCount === -1}
-			<p class="text-xs font-medium text-green-600">
-				✓ Real NetFlow Data Analysis - IPv4 source addresses processed directly
-			</p> -->
 		{:else if data.metadata.uniqueIPCount !== -1}
 			<p class="text-xs text-amber-600">⚠ Using test data from MAAD sample set</p>
 		{/if}

--- a/netflow-webapp/src/routes/api/netflow/files/[slug]/+page.svelte
+++ b/netflow-webapp/src/routes/api/netflow/files/[slug]/+page.svelte
@@ -30,6 +30,10 @@
 	let spectrumDataDestination = $state(new Map<string, SpectrumData>());
 	let singularitiesDataSource = $state(new Map<string, SingularitiesData>());
 	let singularitiesDataDestination = $state(new Map<string, SingularitiesData>());
+	let loadingStructureSource = $state(new Map<string, boolean>());
+	let loadingStructureDestination = $state(new Map<string, boolean>());
+	let loadingSpectrumSource = $state(new Map<string, boolean>());
+	let loadingSpectrumDestination = $state(new Map<string, boolean>());
 	let loadingSingularitiesSource = $state(new Map<string, boolean>());
 	let loadingSingularitiesDestination = $state(new Map<string, boolean>());
 	let errorsSource = $state(new Map<string, string>());
@@ -78,6 +82,10 @@
 		spectrumDataDestination = new Map<string, SpectrumData>();
 		singularitiesDataSource = new Map<string, SingularitiesData>();
 		singularitiesDataDestination = new Map<string, SingularitiesData>();
+		loadingStructureSource = new Map<string, boolean>();
+		loadingStructureDestination = new Map<string, boolean>();
+		loadingSpectrumSource = new Map<string, boolean>();
+		loadingSpectrumDestination = new Map<string, boolean>();
 		loadingSingularitiesSource = new Map<string, boolean>();
 		loadingSingularitiesDestination = new Map<string, boolean>();
 		errorsSource = new Map<string, string>();
@@ -107,26 +115,18 @@
 
 			if (routerDetails.structureSource) {
 				nextStructureSource.set(router, routerDetails.structureSource);
-			} else {
-				nextErrorsSource.set(router, 'Structure statistics not found');
 			}
 
 			if (routerDetails.structureDestination) {
 				nextStructureDestination.set(router, routerDetails.structureDestination);
-			} else {
-				nextErrorsDestination.set(router, 'Structure statistics not found');
 			}
 
 			if (routerDetails.spectrumSource) {
 				nextSpectrumSource.set(router, routerDetails.spectrumSource);
-			} else {
-				nextErrorsSpectrumSource.set(router, 'Spectrum statistics not found');
 			}
 
 			if (routerDetails.spectrumDestination) {
 				nextSpectrumDestination.set(router, routerDetails.spectrumDestination);
-			} else {
-				nextErrorsSpectrumDestination.set(router, 'Spectrum statistics not found');
 			}
 
 			if (routerDetails.ipCountsSource) {
@@ -244,10 +244,6 @@
 			if (token !== loadToken) {
 				return;
 			}
-			console.log(
-				`Singularities data loaded for ${router} (${source ? 'source' : 'destination'}):`,
-				result
-			);
 
 			// Store the result in the appropriate data map
 			if (source) {
@@ -284,12 +280,166 @@
 		}
 	}
 
-	function reloadStructure(_router: string, _source: boolean) {
-		void loadSummary(data.slug);
+	async function loadStructureData(token: number, slug: string, router: string, source: boolean) {
+		const errorMap = source ? errorsSource : errorsDestination;
+		const dataMap = source ? structureFunctionDataSource : structureFunctionDataDestination;
+		const loadingMap = source ? loadingStructureSource : loadingStructureDestination;
+
+		errorMap.set(router, '');
+		loadingMap.set(router, true);
+		if (source) {
+			errorsSource = new Map(errorMap);
+			loadingStructureSource = new Map(loadingMap);
+		} else {
+			errorsDestination = new Map(errorMap);
+			loadingStructureDestination = new Map(loadingMap);
+		}
+
+		try {
+			const response = await fetch(
+				`/api/netflow/files/${slug}/structure?router=${encodeURIComponent(router)}&source=${source}`
+			);
+
+			if (token !== loadToken) {
+				return;
+			}
+
+			if (response.status === 404) {
+				dataMap.delete(router);
+				if (source) {
+					structureFunctionDataSource = new Map(dataMap);
+				} else {
+					structureFunctionDataDestination = new Map(dataMap);
+				}
+				return;
+			}
+
+			if (!response.ok) {
+				let message = `Failed to load structure data: ${response.statusText}`;
+				try {
+					const payload = await response.json();
+					if (payload?.error) {
+						message = payload.error;
+					}
+				} catch {
+					// Ignore JSON parse failures and keep the status text fallback.
+				}
+				throw new Error(message);
+			}
+
+			const result = (await response.json()) as StructureFunctionData;
+			dataMap.set(router, result);
+
+			if (source) {
+				structureFunctionDataSource = new Map(dataMap);
+			} else {
+				structureFunctionDataDestination = new Map(dataMap);
+			}
+		} catch (e) {
+			const errorMessage = e instanceof Error ? e.message : 'Unknown error occurred';
+			dataMap.delete(router);
+			errorMap.set(router, errorMessage);
+
+			if (source) {
+				structureFunctionDataSource = new Map(dataMap);
+				errorsSource = new Map(errorMap);
+			} else {
+				structureFunctionDataDestination = new Map(dataMap);
+				errorsDestination = new Map(errorMap);
+			}
+		} finally {
+			loadingMap.set(router, false);
+			if (source) {
+				loadingStructureSource = new Map(loadingMap);
+			} else {
+				loadingStructureDestination = new Map(loadingMap);
+			}
+		}
 	}
 
-	function reloadSpectrum(_router: string, _source: boolean) {
-		void loadSummary(data.slug);
+	async function loadSpectrumData(token: number, slug: string, router: string, source: boolean) {
+		const errorMap = source ? errorsSpectrumSource : errorsSpectrumDestination;
+		const dataMap = source ? spectrumDataSource : spectrumDataDestination;
+		const loadingMap = source ? loadingSpectrumSource : loadingSpectrumDestination;
+
+		errorMap.set(router, '');
+		loadingMap.set(router, true);
+		if (source) {
+			errorsSpectrumSource = new Map(errorMap);
+			loadingSpectrumSource = new Map(loadingMap);
+		} else {
+			errorsSpectrumDestination = new Map(errorMap);
+			loadingSpectrumDestination = new Map(loadingMap);
+		}
+
+		try {
+			const response = await fetch(
+				`/api/netflow/files/${slug}/spectrum?router=${encodeURIComponent(router)}&source=${source}`
+			);
+
+			if (token !== loadToken) {
+				return;
+			}
+
+			if (response.status === 404) {
+				dataMap.delete(router);
+				if (source) {
+					spectrumDataSource = new Map(dataMap);
+				} else {
+					spectrumDataDestination = new Map(dataMap);
+				}
+				return;
+			}
+
+			if (!response.ok) {
+				let message = `Failed to load spectrum data: ${response.statusText}`;
+				try {
+					const payload = await response.json();
+					if (payload?.error) {
+						message = payload.error;
+					}
+				} catch {
+					// Ignore JSON parse failures and keep the status text fallback.
+				}
+				throw new Error(message);
+			}
+
+			const result = (await response.json()) as SpectrumData;
+			dataMap.set(router, result);
+
+			if (source) {
+				spectrumDataSource = new Map(dataMap);
+			} else {
+				spectrumDataDestination = new Map(dataMap);
+			}
+		} catch (e) {
+			const errorMessage = e instanceof Error ? e.message : 'Unknown error occurred';
+			dataMap.delete(router);
+			errorMap.set(router, errorMessage);
+
+			if (source) {
+				spectrumDataSource = new Map(dataMap);
+				errorsSpectrumSource = new Map(errorMap);
+			} else {
+				spectrumDataDestination = new Map(dataMap);
+				errorsSpectrumDestination = new Map(errorMap);
+			}
+		} finally {
+			loadingMap.set(router, false);
+			if (source) {
+				loadingSpectrumSource = new Map(loadingMap);
+			} else {
+				loadingSpectrumDestination = new Map(loadingMap);
+			}
+		}
+	}
+
+	function reloadStructure(router: string, source: boolean) {
+		void loadStructureData(loadToken, data.slug, router, source);
+	}
+
+	function reloadSpectrum(router: string, source: boolean) {
+		void loadSpectrumData(loadToken, data.slug, router, source);
 	}
 
 	function reloadSingularities(router: string, source: boolean) {
@@ -485,176 +635,191 @@
 						</div>
 					</div>
 
-					<!-- MAAD Analysis for this Router -->
+					<!-- Analysis for this Router -->
 					<div class="rounded-b-lg p-4">
 						<h4 class="text-md mb-4 font-semibold text-gray-800">MAAD Analysis</h4>
-
-						<!-- Structure Function Analysis -->
-						<div class="mb-6">
-							<h5 class="text-md mb-3 font-medium text-gray-700">Structure Function tau(q)</h5>
-							<div class="grid grid-cols-1 gap-6 lg:grid-cols-2">
-								<!-- Source Address Analysis -->
-								<div class="space-y-3">
-									<h6 class="text-sm font-medium text-blue-700">Source Address Analysis</h6>
-									{#if errorsSource.get(record.router)}
-										<div class="rounded border border-red-200 bg-red-50 p-4 text-red-700">
-											<p>Error loading source analysis: {errorsSource.get(record.router)}</p>
-											<button
-												class="mt-2 rounded bg-red-600 px-3 py-1 text-sm text-white hover:bg-red-700"
-												onclick={() => reloadStructure(record.router, true)}
-											>
-												Retry Source
-											</button>
-										</div>
-									{:else if structureFunctionDataSource.get(record.router)}
-										<StructureFunctionChart
-											data={structureFunctionDataSource.get(record.router)!}
-										/>
-									{:else}
-										<div class="rounded border bg-gray-50 p-4 text-gray-600">
-											No source structure statistics available.
-										</div>
-									{/if}
-								</div>
-
-								<!-- Destination Address Analysis -->
-								<div class="space-y-3">
-									<h6 class="text-sm font-medium text-blue-700">Destination Address Analysis</h6>
-									{#if errorsDestination.get(record.router)}
-										<div class="rounded border border-red-200 bg-red-50 p-4 text-red-700">
-											<p>
-												Error loading destination analysis: {errorsDestination.get(record.router)}
-											</p>
-											<button
-												class="mt-2 rounded bg-red-600 px-3 py-1 text-sm text-white hover:bg-red-700"
-												onclick={() => reloadStructure(record.router, false)}
-											>
-												Retry Destination
-											</button>
-										</div>
-									{:else if structureFunctionDataDestination.get(record.router)}
-										<StructureFunctionChart
-											data={structureFunctionDataDestination.get(record.router)!}
-										/>
-									{:else}
-										<div class="rounded border bg-gray-50 p-4 text-gray-600">
-											No destination structure statistics available.
-										</div>
-									{/if}
+						<div class="mb-6 grid grid-cols-1 gap-6 lg:grid-cols-2">
+							<h5 class="hidden border-b pb-2 text-base font-semibold text-blue-700 lg:block">
+								Source
+							</h5>
+							<h5 class="hidden border-b pb-2 text-base font-semibold text-blue-700 lg:block">
+								Destination
+							</h5>
+						</div>
+						<div class="space-y-6">
+							<div class="space-y-3">
+								<h6 class="text-md font-medium text-gray-700">Structure</h6>
+								<div class="grid grid-cols-1 gap-6 lg:grid-cols-2">
+									<div>
+										{#if loadingStructureSource.get(record.router)}
+											<div class="flex items-center justify-center py-6">
+												<div class="text-gray-600">Loading source structure...</div>
+											</div>
+										{:else if errorsSource.get(record.router)}
+											<div class="rounded border border-red-200 bg-red-50 p-4 text-red-700">
+												<p>Error loading source structure: {errorsSource.get(record.router)}</p>
+												<button
+													class="mt-2 rounded bg-red-600 px-3 py-1 text-sm text-white hover:bg-red-700"
+													onclick={() => reloadStructure(record.router, true)}
+												>
+													Retry Source
+												</button>
+											</div>
+										{:else if structureFunctionDataSource.get(record.router)}
+											<StructureFunctionChart
+												data={structureFunctionDataSource.get(record.router)!}
+											/>
+										{:else}
+											<div class="rounded border bg-gray-50 p-4 text-gray-600">
+												No source structure available.
+											</div>
+										{/if}
+									</div>
+									<div>
+										{#if loadingStructureDestination.get(record.router)}
+											<div class="flex items-center justify-center py-6">
+												<div class="text-gray-600">Loading destination structure...</div>
+											</div>
+										{:else if errorsDestination.get(record.router)}
+											<div class="rounded border border-red-200 bg-red-50 p-4 text-red-700">
+												<p>
+													Error loading destination structure: {errorsDestination.get(
+														record.router
+													)}
+												</p>
+												<button
+													class="mt-2 rounded bg-red-600 px-3 py-1 text-sm text-white hover:bg-red-700"
+													onclick={() => reloadStructure(record.router, false)}
+												>
+													Retry Destination
+												</button>
+											</div>
+										{:else if structureFunctionDataDestination.get(record.router)}
+											<StructureFunctionChart
+												data={structureFunctionDataDestination.get(record.router)!}
+											/>
+										{:else}
+											<div class="rounded border bg-gray-50 p-4 text-gray-600">
+												No destination structure available.
+											</div>
+										{/if}
+									</div>
 								</div>
 							</div>
-						</div>
-
-						<!-- Multifractal Spectrum Analysis -->
-						<div class="mb-4">
-							<h5 class="text-md mb-3 font-medium text-gray-700">Spectrum f(alpha)</h5>
-							<div class="grid grid-cols-1 gap-6 lg:grid-cols-2">
-								<!-- Source Address Spectrum -->
-								<div class="space-y-3">
-									<h6 class="text-sm font-medium text-blue-700">Source Address Spectrum</h6>
-									{#if errorsSpectrumSource.get(record.router)}
-										<div class="rounded border border-red-200 bg-red-50 p-4 text-red-700">
-											<p>
-												Error loading source spectrum: {errorsSpectrumSource.get(record.router)}
-											</p>
-											<button
-												class="mt-2 rounded bg-red-600 px-3 py-1 text-sm text-white hover:bg-red-700"
-												onclick={() => reloadSpectrum(record.router, true)}
-											>
-												Retry Source
-											</button>
-										</div>
-									{:else if spectrumDataSource.get(record.router)}
-										<SpectrumChart data={spectrumDataSource.get(record.router)!} />
-									{:else}
-										<div class="rounded border bg-gray-50 p-4 text-gray-600">
-											No source spectrum statistics available.
-										</div>
-									{/if}
-								</div>
-
-								<!-- Destination Address Spectrum -->
-								<div class="space-y-3">
-									<h6 class="text-sm font-medium text-blue-700">Destination Address Spectrum</h6>
-									{#if errorsSpectrumDestination.get(record.router)}
-										<div class="rounded border border-red-200 bg-red-50 p-4 text-red-700">
-											<p>
-												Error loading destination spectrum: {errorsSpectrumDestination.get(
-													record.router
-												)}
-											</p>
-											<button
-												class="mt-2 rounded bg-red-600 px-3 py-1 text-sm text-white hover:bg-red-700"
-												onclick={() => reloadSpectrum(record.router, false)}
-											>
-												Retry Destination
-											</button>
-										</div>
-									{:else if spectrumDataDestination.get(record.router)}
-										<SpectrumChart data={spectrumDataDestination.get(record.router)!} />
-									{:else}
-										<div class="rounded border bg-gray-50 p-4 text-gray-600">
-											No destination spectrum statistics available.
-										</div>
-									{/if}
+							<div class="space-y-3">
+								<h6 class="text-md font-medium text-gray-700">Spectrum</h6>
+								<div class="grid grid-cols-1 gap-6 lg:grid-cols-2">
+									<div>
+										{#if loadingSpectrumSource.get(record.router)}
+											<div class="flex items-center justify-center py-6">
+												<div class="text-gray-600">Loading source spectrum...</div>
+											</div>
+										{:else if errorsSpectrumSource.get(record.router)}
+											<div class="rounded border border-red-200 bg-red-50 p-4 text-red-700">
+												<p>
+													Error loading source spectrum: {errorsSpectrumSource.get(record.router)}
+												</p>
+												<button
+													class="mt-2 rounded bg-red-600 px-3 py-1 text-sm text-white hover:bg-red-700"
+													onclick={() => reloadSpectrum(record.router, true)}
+												>
+													Retry Source
+												</button>
+											</div>
+										{:else if spectrumDataSource.get(record.router)}
+											<SpectrumChart data={spectrumDataSource.get(record.router)!} />
+										{:else}
+											<div class="rounded border bg-gray-50 p-4 text-gray-600">
+												No source spectrum available.
+											</div>
+										{/if}
+									</div>
+									<div>
+										{#if loadingSpectrumDestination.get(record.router)}
+											<div class="flex items-center justify-center py-6">
+												<div class="text-gray-600">Loading destination spectrum...</div>
+											</div>
+										{:else if errorsSpectrumDestination.get(record.router)}
+											<div class="rounded border border-red-200 bg-red-50 p-4 text-red-700">
+												<p>
+													Error loading destination spectrum: {errorsSpectrumDestination.get(
+														record.router
+													)}
+												</p>
+												<button
+													class="mt-2 rounded bg-red-600 px-3 py-1 text-sm text-white hover:bg-red-700"
+													onclick={() => reloadSpectrum(record.router, false)}
+												>
+													Retry Destination
+												</button>
+											</div>
+										{:else if spectrumDataDestination.get(record.router)}
+											<SpectrumChart data={spectrumDataDestination.get(record.router)!} />
+										{:else}
+											<div class="rounded border bg-gray-50 p-4 text-gray-600">
+												No destination spectrum available.
+											</div>
+										{/if}
+									</div>
 								</div>
 							</div>
-						</div>
-						<!-- Singularities Analysis -->
-						<div class="space-y-4">
-							<h5 class="text-lg font-semibold">Singularities Analysis</h5>
-							<div class="grid grid-cols-1 gap-6 lg:grid-cols-2">
-								<!-- Source Address Singularities -->
-								<div class="space-y-3">
-									<h6 class="text-sm font-medium text-blue-700">Source Address Singularities</h6>
-									{#if loadingSingularitiesSource.get(record.router)}
-										<div class="flex items-center justify-center py-6">
-											<div class="text-gray-600">Loading source singularities analysis...</div>
-										</div>
-									{:else if errorsSingularitiesSource.get(record.router)}
-										<div class="rounded-lg border border-red-300 bg-red-50 p-4">
-											<p class="text-red-700">
-												Error loading source singularities: {errorsSingularitiesSource.get(
-													record.router
-												)}
-											</p>
-											<button
-												class="mt-2 rounded bg-red-600 px-3 py-1 text-sm text-white hover:bg-red-700"
-												onclick={() => reloadSingularities(record.router, true)}
-											>
-												Retry Source
-											</button>
-										</div>
-									{:else if singularitiesDataSource.get(record.router)}
-										<SingularitiesList data={singularitiesDataSource.get(record.router)!} />
-									{/if}
-								</div>
-								<!-- Destination Address Singularities -->
-								<div class="space-y-3">
-									<h6 class="text-sm font-medium text-blue-700">
-										Destination Address Singularities
-									</h6>
-									{#if loadingSingularitiesDestination.get(record.router)}
-										<div class="flex items-center justify-center py-6">
-											<div class="text-gray-600">Loading destination singularities analysis...</div>
-										</div>
-									{:else if errorsSingularitiesDestination.get(record.router)}
-										<div class="rounded-lg border border-red-300 bg-red-50 p-4">
-											<p class="text-red-700">
-												Error loading destination singularities: {errorsSingularitiesDestination.get(
-													record.router
-												)}
-											</p>
-											<button
-												class="mt-2 rounded bg-red-600 px-3 py-1 text-sm text-white hover:bg-red-700"
-												onclick={() => reloadSingularities(record.router, false)}
-											>
-												Retry Destination
-											</button>
-										</div>
-									{:else if singularitiesDataDestination.get(record.router)}
-										<SingularitiesList data={singularitiesDataDestination.get(record.router)!} />
-									{/if}
+							<div class="space-y-3">
+								<h6 class="text-md font-medium text-gray-700">Singularities</h6>
+								<div class="grid grid-cols-1 gap-6 lg:grid-cols-2">
+									<div>
+										{#if loadingSingularitiesSource.get(record.router)}
+											<div class="flex items-center justify-center py-6">
+												<div class="text-gray-600">Loading source singularities...</div>
+											</div>
+										{:else if errorsSingularitiesSource.get(record.router)}
+											<div class="rounded-lg border border-red-300 bg-red-50 p-4">
+												<p class="text-red-700">
+													Error loading source singularities: {errorsSingularitiesSource.get(
+														record.router
+													)}
+												</p>
+												<button
+													class="mt-2 rounded bg-red-600 px-3 py-1 text-sm text-white hover:bg-red-700"
+													onclick={() => reloadSingularities(record.router, true)}
+												>
+													Retry Source
+												</button>
+											</div>
+										{:else if singularitiesDataSource.get(record.router)}
+											<SingularitiesList data={singularitiesDataSource.get(record.router)!} />
+										{:else}
+											<div class="rounded border bg-gray-50 p-4 text-gray-600">
+												No source singularities available.
+											</div>
+										{/if}
+									</div>
+									<div>
+										{#if loadingSingularitiesDestination.get(record.router)}
+											<div class="flex items-center justify-center py-6">
+												<div class="text-gray-600">Loading destination singularities...</div>
+											</div>
+										{:else if errorsSingularitiesDestination.get(record.router)}
+											<div class="rounded-lg border border-red-300 bg-red-50 p-4">
+												<p class="text-red-700">
+													Error loading destination singularities: {errorsSingularitiesDestination.get(
+														record.router
+													)}
+												</p>
+												<button
+													class="mt-2 rounded bg-red-600 px-3 py-1 text-sm text-white hover:bg-red-700"
+													onclick={() => reloadSingularities(record.router, false)}
+												>
+													Retry Destination
+												</button>
+											</div>
+										{:else if singularitiesDataDestination.get(record.router)}
+											<SingularitiesList data={singularitiesDataDestination.get(record.router)!} />
+										{:else}
+											<div class="rounded border bg-gray-50 p-4 text-gray-600">
+												No destination singularities available.
+											</div>
+										{/if}
+									</div>
 								</div>
 							</div>
 						</div>

--- a/netflow-webapp/src/routes/api/netflow/files/[slug]/details/+server.ts
+++ b/netflow-webapp/src/routes/api/netflow/files/[slug]/details/+server.ts
@@ -53,7 +53,7 @@ function buildStructureData(
 	addressType: 'Source' | 'Destination',
 	points: StructureFunctionPoint[] | null
 ): StructureFunctionData | null {
-	if (!points) return null;
+	if (!points || points.length === 0) return null;
 
 	const qValues = points.map((point) => point.q);
 	const qRange =
@@ -82,7 +82,7 @@ function buildSpectrumData(
 	addressType: 'Source' | 'Destination',
 	points: SpectrumPoint[] | null
 ): SpectrumData | null {
-	if (!points) return null;
+	if (!points || points.length === 0) return null;
 
 	const alphaValues = points.map((point) => point.alpha);
 	const alphaRange =

--- a/netflow-webapp/src/routes/api/netflow/files/[slug]/spectrum/+server.ts
+++ b/netflow-webapp/src/routes/api/netflow/files/[slug]/spectrum/+server.ts
@@ -6,8 +6,8 @@ import { getDb, slugToBucketStart } from '../utils';
 const FIVE_MINUTES = '5m';
 
 type SpectrumRow = {
-	spectrumJsonSa: string;
-	spectrumJsonDa: string;
+	spectrumJsonSa: string | null;
+	spectrumJsonDa: string | null;
 };
 
 export const GET: RequestHandler = async ({ params, url }) => {
@@ -61,15 +61,27 @@ export const GET: RequestHandler = async ({ params, url }) => {
 		}
 
 		const rawSpectrum = isSource ? row.spectrumJsonSa : row.spectrumJsonDa;
+		if (!rawSpectrum) {
+			return json(
+				{ error: `Spectrum statistics not found for router ${router} at ${slug}` },
+				{ status: 404 }
+			);
+		}
+
 		let data: SpectrumPoint[] = [];
 
 		try {
-			if (rawSpectrum) {
-				data = JSON.parse(rawSpectrum) as SpectrumPoint[];
-			}
+			data = JSON.parse(rawSpectrum) as SpectrumPoint[];
 		} catch (error) {
 			console.error('Failed to parse spectrum JSON from database:', error);
 			return json({ error: 'Failed to parse spectrum statistics' }, { status: 500 });
+		}
+
+		if (data.length === 0) {
+			return json(
+				{ error: `Spectrum statistics not found for router ${router} at ${slug}` },
+				{ status: 404 }
+			);
 		}
 
 		const addressType = isSource ? 'Source' : 'Destination';

--- a/netflow-webapp/src/routes/api/netflow/files/[slug]/structure/+server.ts
+++ b/netflow-webapp/src/routes/api/netflow/files/[slug]/structure/+server.ts
@@ -1,30 +1,13 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
-import type { StructureFunctionPoint } from '$lib/types/types';
+import type { StructureFunctionData, StructureFunctionPoint } from '$lib/types/types';
 import { getDb, slugToBucketStart } from '../utils';
 
 const FIVE_MINUTES = '5m';
 
 type StructureRow = {
-	structureJsonSa: string;
-	structureJsonDa: string;
-};
-
-type StructureResponse = {
-	slug: string;
-	router: string;
-	filename: string;
-	structureFunction: StructureFunctionPoint[];
-	metadata: {
-		dataSource: string;
-		uniqueIPCount?: number;
-		pointCount: number;
-		addressType: string;
-		qRange: {
-			min: number;
-			max: number;
-		};
-	};
+	structureJsonSa: string | null;
+	structureJsonDa: string | null;
 };
 
 export const GET: RequestHandler = async ({ params, url }) => {
@@ -78,15 +61,27 @@ export const GET: RequestHandler = async ({ params, url }) => {
 		}
 
 		const rawStructure = isSource ? row.structureJsonSa : row.structureJsonDa;
+		if (!rawStructure) {
+			return json(
+				{ error: `Structure statistics not found for router ${router} at ${slug}` },
+				{ status: 404 }
+			);
+		}
+
 		let data: StructureFunctionPoint[] = [];
 
 		try {
-			if (rawStructure) {
-				data = JSON.parse(rawStructure) as StructureFunctionPoint[];
-			}
+			data = JSON.parse(rawStructure) as StructureFunctionPoint[];
 		} catch (error) {
 			console.error('Failed to parse structure JSON from database:', error);
 			return json({ error: 'Failed to parse structure statistics' }, { status: 500 });
+		}
+
+		if (data.length === 0) {
+			return json(
+				{ error: `Structure statistics not found for router ${router} at ${slug}` },
+				{ status: 404 }
+			);
 		}
 
 		const addressType = isSource ? 'Source' : 'Destination';
@@ -96,7 +91,7 @@ export const GET: RequestHandler = async ({ params, url }) => {
 				? { min: Math.min(...qValues), max: Math.max(...qValues) }
 				: { min: 0, max: 0 };
 
-		const response: StructureResponse = {
+		const response: StructureFunctionData = {
 			slug,
 			router,
 			filename: `nfcapd.${slug}`,


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR simplifies the file analysis page by consolidating per-chart headings into a shared "Source / Destination" column header, removing debug `console.log` calls, stripping redundant metadata paragraphs from the chart components, and replacing the old `reloadStructure`/`reloadSpectrum` stubs (which re-ran the full page load) with focused `loadStructureData`/`loadSpectrumData` async functions that only refetch the single affected dataset. The server-side changes also harden null/empty-array handling in the structure and spectrum endpoints.

Key changes:
- **UI**: Chart component titles (Chart.js `plugins.title`) and inline metadata rows removed; a single `Source / Destination` header row now sits above all three analysis grids in `+page.svelte`.
- **Retry logic**: `reloadStructure` and `reloadSpectrum` now call dedicated async functions instead of triggering a full `loadSummary`, which avoids unnecessarily re-fetching all router data and re-running singularity loads on every retry.
- **Server robustness**: `structure/+server.ts` and `spectrum/+server.ts` now correctly declare `string | null` column types and return HTTP 404 (instead of empty data) when a column is `null` or the parsed array is empty; the same guard was added to `details/+server.ts`.
- **Cleanup**: Debug `console.log` statements removed from `SpectrumChart`, `StructureFunctionChart`, and the singularities load path.

**UX issues:** The shared Source/Destination header grid breaks on viewports narrower than `lg`, and the retry path for structure/spectrum lacks loading indicators that singularities already provides.

<h3>Confidence Score: 4/5</h3>

- The logic changes are well-scoped and correct — null-safety fixes and dedicated refetch functions all improve correctness. Minor UX issues remain on small-screen layouts and retry flows.
- The backend changes (structure/spectrum/details servers) are solid — they correctly handle empty arrays and nulls by returning 404. The refetch functions (`loadStructureData`, `loadSpectrumData`) are correctly implemented. The two UX concerns are legitimate but non-critical: (1) the shared header grid misaligns on mobile due to stacking in single-column mode, and (2) structure/spectrum retries lack loading indicators, creating silent UX gaps during in-flight requests. Neither causes data loss or breaks functionality, but both degrade user experience. Safe to merge with these known issues.
- netflow-webapp/src/routes/api/netflow/files/[slug]/+page.svelte — requires UX adjustments for mobile header layout and loading state feedback on retry.

<sub>Last reviewed commit: f06c831</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->