### PR TITLE
feat(pipeline): add attempted-file timing summary

### DIFF
--- a/netflow-db/flow_db.py
+++ b/netflow-db/flow_db.py
@@ -222,7 +222,7 @@ def process_pending_files(
         limit: Optional limit on number of files to process
         
     Returns:
-        Dictionary with counts: {'processed': N, 'errors': N}
+        Dictionary with counts: {'processed': N, 'errors': N, 'attempted': N}
     """
     init_netflow_stats_table(conn)
     
@@ -236,12 +236,13 @@ def process_pending_files(
         limit,
         reprocess_window_days=reprocess_window_days,
     )
-    stats = {'processed': 0, 'errors': 0}
+    stats = {'processed': 0, 'errors': 0, 'attempted': 0}
     
     if not pending:
         print("[flow_stats] No pending files to process")
         return stats
     
+    stats['attempted'] = len(pending)
     print(f"[flow_stats] Processing {len(pending)} pending files with {MAX_WORKERS} workers...")
     
     # Process in batches

--- a/netflow-db/ip_db.py
+++ b/netflow-db/ip_db.py
@@ -314,12 +314,13 @@ def process_pending_files(
         limit,
         reprocess_window_days=reprocess_window_days,
     )
-    stats = {'processed': 0, 'errors': 0, 'aggregates': 0, 'days': 0}
+    stats = {'processed': 0, 'errors': 0, 'aggregates': 0, 'days': 0, 'attempted': 0}
     
     if not pending:
         print("[ip_stats] No pending files to process")
         return stats
     
+    stats['attempted'] = len(pending)
     # Group by day
     days = group_files_by_day(pending)
     print(f"[ip_stats] Processing {len(pending)} files across {len(days)} complete days...")

--- a/netflow-db/pipeline.py
+++ b/netflow-db/pipeline.py
@@ -34,6 +34,7 @@ from pathlib import Path
 from common import (
     DATABASE_PATH,
     AVAILABLE_ROUTERS,
+    MAX_WORKERS,
     get_db_connection,
     init_processed_files_table,
 )
@@ -90,6 +91,14 @@ def setup_logging(log_dir: Path = None):
     return log_file
 
 
+def format_elapsed(seconds: float) -> str:
+    """Format elapsed seconds as HH:MM:SS."""
+    total_seconds = int(round(seconds))
+    hours, remainder = divmod(total_seconds, 3600)
+    minutes, secs = divmod(remainder, 60)
+    return f"{hours:02d}:{minutes:02d}:{secs:02d}"
+
+
 def run_discovery(
     conn: sqlite3.Connection,
     reprocess_window_days: int = 30,
@@ -112,12 +121,14 @@ def run_discovery(
     print("PHASE 1: FILE DISCOVERY")
     print("=" * 60)
     
+    phase_start = datetime.now()
     stats = sync_processed_files_table(
         conn,
         include_gaps=True,
         reprocess_window_days=reprocess_window_days,
         discovery_window_days=discovery_window_days,
     )
+    stats['elapsed_seconds'] = (datetime.now() - phase_start).total_seconds()
     
     horizon = compute_data_horizon(conn)
     print(f"\nData horizon: {horizon}")
@@ -181,7 +192,9 @@ def run_processing(
             processor.init_structure_stats_table(conn)
         
         # Process pending files
+        phase_start = datetime.now()
         stats = processor.process_pending_files(conn, limit, reprocess_window_days)
+        stats['elapsed_seconds'] = (datetime.now() - phase_start).total_seconds()
         all_stats[table_name] = stats
         
         print(f"{table_name}: {stats['processed']} processed, {stats['errors']} errors")
@@ -200,16 +213,41 @@ def print_summary(discovery_stats: dict, processing_stats: dict):
         print(f"  Files discovered: {discovery_stats.get('discovered', 0)}")
         print(f"  New files: {discovery_stats.get('new_files', 0)}")
         print(f"  Gaps identified: {discovery_stats.get('gaps', 0)}")
+        print(f"  Elapsed: {format_elapsed(discovery_stats.get('elapsed_seconds', 0.0))}")
     
     if processing_stats:
         print("\nProcessing:")
         total_processed = 0
         total_errors = 0
+        total_attempted = 0
+        total_elapsed_seconds = 0.0
         for table, stats in processing_stats.items():
-            print(f"  {table}: {stats['processed']} processed, {stats['errors']} errors")
+            attempted = stats.get('attempted', 0)
+            elapsed_seconds = stats.get('elapsed_seconds', 0.0)
+            avg_per_file = (
+                f"{elapsed_seconds / attempted:.2f}s/file with {MAX_WORKERS} workers"
+                if attempted
+                else f"n/a with {MAX_WORKERS} workers"
+            )
+            print(
+                f"  {table}: {format_elapsed(elapsed_seconds)} total, "
+                f"{attempted} attempted files, {avg_per_file}, "
+                f"{stats['processed']} processed, {stats['errors']} errors"
+            )
             total_processed += stats['processed']
             total_errors += stats['errors']
-        print(f"  TOTAL: {total_processed} processed, {total_errors} errors")
+            total_attempted += attempted
+            total_elapsed_seconds += elapsed_seconds
+        total_avg_per_file = (
+            f"{total_elapsed_seconds / total_attempted:.2f}s/file with {MAX_WORKERS} workers"
+            if total_attempted
+            else f"n/a with {MAX_WORKERS} workers"
+        )
+        print(
+            f"  TOTAL: {format_elapsed(total_elapsed_seconds)} total, "
+            f"{total_attempted} attempted files, {total_avg_per_file}, "
+            f"{total_processed} processed, {total_errors} errors"
+        )
 
 
 def main():

--- a/netflow-db/protocol_db.py
+++ b/netflow-db/protocol_db.py
@@ -303,12 +303,13 @@ def process_pending_files(
         limit,
         reprocess_window_days=reprocess_window_days,
     )
-    stats = {'processed': 0, 'errors': 0, 'aggregates': 0, 'days': 0}
+    stats = {'processed': 0, 'errors': 0, 'aggregates': 0, 'days': 0, 'attempted': 0}
     
     if not pending:
         print("[protocol_stats] No pending files to process")
         return stats
     
+    stats['attempted'] = len(pending)
     # Group by day
     days = group_files_by_day(pending)
     print(f"[protocol_stats] Processing {len(pending)} files across {len(days)} complete days...")

--- a/netflow-db/spectrum_db.py
+++ b/netflow-db/spectrum_db.py
@@ -383,12 +383,13 @@ def process_pending_files(
         limit,
         reprocess_window_days=reprocess_window_days,
     )
-    stats = {'processed': 0, 'errors': 0, 'aggregates': 0, 'days': 0}
+    stats = {'processed': 0, 'errors': 0, 'aggregates': 0, 'days': 0, 'attempted': 0}
     
     if not pending:
         print("[spectrum_stats] No pending files to process")
         return stats
     
+    stats['attempted'] = len(pending)
     # Group by day
     days = group_files_by_day(pending)
     print(f"[spectrum_stats] Processing {len(pending)} files across {len(days)} complete days...")

--- a/netflow-db/structure_db.py
+++ b/netflow-db/structure_db.py
@@ -384,12 +384,13 @@ def process_pending_files(
         limit,
         reprocess_window_days=reprocess_window_days,
     )
-    stats = {'processed': 0, 'errors': 0, 'aggregates': 0, 'days': 0}
+    stats = {'processed': 0, 'errors': 0, 'aggregates': 0, 'days': 0, 'attempted': 0}
     
     if not pending:
         print("[structure_stats] No pending files to process")
         return stats
     
+    stats['attempted'] = len(pending)
     # Group by day
     days = group_files_by_day(pending)
     print(f"[structure_stats] Processing {len(pending)} files across {len(days)} complete days...")

--- a/netflow-webapp/src/lib/components/charts/chart-utils.ts
+++ b/netflow-webapp/src/lib/components/charts/chart-utils.ts
@@ -268,9 +268,7 @@ export function groupByBucketDurationMs(groupBy: GroupByOption): number {
  * Thresholds are calibrated from existing click drilldown windows:
  * 1 day -> 5min, 7 days -> 30min, 31 days -> hour.
  */
-export function chooseAdaptiveGranularity(
-	rangeMs: number
-): GroupByOption {
+export function chooseAdaptiveGranularity(rangeMs: number): GroupByOption {
 	const oneDay = 24 * 60 * 60 * 1000;
 	const sevenDays = 7 * oneDay;
 	const thirtyOneDays = 31 * oneDay;

--- a/netflow-webapp/src/routes/+layout.svelte
+++ b/netflow-webapp/src/routes/+layout.svelte
@@ -11,7 +11,7 @@
 				<h1 class="text-3xl font-bold text-gray-900 hover:underline">
 					<a href="/">NetFlow Analysis</a>
 				</h1>
-				<p class="mt-1 text-sm text-gray-600">An Oregon Network Research Group Project</p>
+				<p class="mt-1 text-sm text-gray-600">An Oregon Networking Research Group Project</p>
 			</div>
 			<div class="flex items-center gap-4">
 				<a href="/" class="text-gray-500 hover:text-gray-900">Home</a>


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a lightweight timing and file-count summary to the pipeline's final output. Each processor now tracks an `'attempted'` count (files queued for processing) and the orchestrator (`pipeline.py`) records wall-clock elapsed time per phase, then prints a formatted summary with per-table and aggregate throughput metrics (`HH:MM:SS`, files attempted, and average seconds/file).

The changes are consistent across all five processor modules and the implementation is clean. One minor documentation point: the `process_pending_files` docstring in `flow_db.py` was not updated to include the new `'attempted'` return key.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — changes are additive, non-breaking, and consistent across all processor modules.
- All changes are purely additive (new dict keys, timing captures, and summary formatting). No existing logic is altered, no database schema is touched, and the new code paths have correct zero-guards. Only one minor documentation issue identified.
- No files require special attention

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `netflow-db/flow_db.py`, line 224-225 ([link](https://github.com/flamboh/netflow-analysis/blob/20845d54abc9d1c215a26600f5ff6eaa9244761a/netflow-db/flow_db.py#L224-L225)) 

   The docstring should list all keys returned in the stats dict, including the new `'attempted'` key that is set at line 245.

</details>

<!-- /greptile_failed_comments -->

<sub>Last reviewed commit: 20845d5</sub>

<!-- /greptile_comment -->