### PR TITLE
fix(netflow): harden v2 rollup migration

### DIFF
--- a/tests/python/test_verify_web_compatible_v2.py
+++ b/tests/python/test_verify_web_compatible_v2.py
@@ -12,8 +12,7 @@ def load_modules():
     return importlib.reload(pipeline_v2), importlib.reload(verifier)
 
 
-def test_verify_web_compatible_v2_accepts_pipeline_csv_db(tmp_path: Path) -> None:
-    pipeline_v2, verifier = load_modules()
+def build_two_flow_csv_db(tmp_path: Path, pipeline_v2) -> Path:
     mapping_path = tmp_path / 'mapping.json'
     mapping_path.write_text(
         json.dumps(
@@ -58,6 +57,12 @@ def test_verify_web_compatible_v2_accepts_pipeline_csv_db(tmp_path: Path) -> Non
             max_workers=1,
             run_maad=False,
         )
+    return db_path
+
+
+def test_verify_web_compatible_v2_accepts_pipeline_csv_db(tmp_path: Path) -> None:
+    pipeline_v2, verifier = load_modules()
+    db_path = build_two_flow_csv_db(tmp_path, pipeline_v2)
 
     verifier.verify_database(
         db_path,
@@ -70,50 +75,7 @@ def test_verify_web_compatible_v2_accepts_pipeline_csv_db(tmp_path: Path) -> Non
 
 def test_verify_web_compatible_v2_requires_maad_rows_when_requested(tmp_path: Path) -> None:
     pipeline_v2, verifier = load_modules()
-    mapping_path = tmp_path / 'mapping.json'
-    mapping_path.write_text(
-        json.dumps(
-            {
-                'timestamp_format': 'unix',
-                'columns': {
-                    'time_received': 'received_at',
-                    'src_ip': 'src',
-                    'dst_ip': 'dst',
-                    'protocol': 'pr',
-                    'packets': 'pkt',
-                    'bytes': 'byt',
-                },
-                'source_id': {'value': 'ugr16'},
-            }
-        ),
-        encoding='utf-8',
-    )
-    csv_path = tmp_path / 'flows.csv'
-    csv_path.write_text(
-        '\n'.join(
-            [
-                'received_at,src,dst,pr,pkt,byt',
-                '1744732801,192.0.2.1,198.51.100.1,6,10,1000',
-                '1744733101,192.0.2.2,198.51.100.2,17,20,2000',
-            ]
-        )
-        + '\n',
-        encoding='utf-8',
-    )
-    db_path = tmp_path / 'netflow.sqlite'
-    with sqlite3.connect(db_path) as conn:
-        pipeline_v2.process_input_specs(
-            conn,
-            [
-                {
-                    'input_kind': 'csv',
-                    'path': str(csv_path),
-                    'mapping_path': str(mapping_path),
-                }
-            ],
-            max_workers=1,
-            run_maad=False,
-        )
+    db_path = build_two_flow_csv_db(tmp_path, pipeline_v2)
 
     with pytest.raises(SystemExit, match='structure_stats_v2 has no rows'):
         verifier.verify_database(
@@ -125,52 +87,45 @@ def test_verify_web_compatible_v2_requires_maad_rows_when_requested(tmp_path: Pa
         )
 
 
+def test_verify_web_compatible_v2_requires_netflow_rollup_rows(tmp_path: Path) -> None:
+    pipeline_v2, verifier = load_modules()
+    db_path = build_two_flow_csv_db(tmp_path, pipeline_v2)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute('DELETE FROM netflow_stats_aggregate_v2')
+
+    with pytest.raises(SystemExit, match='netflow_stats_aggregate_v2 has no rows'):
+        verifier.verify_database(
+            db_path,
+            source_id='ugr16',
+            require_data=True,
+        )
+
+
+def test_verify_web_compatible_v2_rejects_netflow_rollup_mismatch(tmp_path: Path) -> None:
+    pipeline_v2, verifier = load_modules()
+    db_path = build_two_flow_csv_db(tmp_path, pipeline_v2)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            UPDATE netflow_stats_aggregate_v2
+            SET flows = flows + 1
+            WHERE granularity = '1h'
+            """
+        )
+
+    with pytest.raises(SystemExit, match='netflow_stats_aggregate_v2 parity failed'):
+        verifier.verify_database(
+            db_path,
+            source_id='ugr16',
+            require_data=True,
+            require_processed=True,
+        )
+
+
 def test_verify_web_compatible_v2_rejects_persisted_raw_ipv4_text(tmp_path: Path) -> None:
     pipeline_v2, verifier = load_modules()
-    mapping_path = tmp_path / 'mapping.json'
-    mapping_path.write_text(
-        json.dumps(
-            {
-                'timestamp_format': 'unix',
-                'columns': {
-                    'time_received': 'received_at',
-                    'src_ip': 'src',
-                    'dst_ip': 'dst',
-                    'protocol': 'pr',
-                    'packets': 'pkt',
-                    'bytes': 'byt',
-                },
-                'source_id': {'value': 'ugr16'},
-            }
-        ),
-        encoding='utf-8',
-    )
-    csv_path = tmp_path / 'flows.csv'
-    csv_path.write_text(
-        '\n'.join(
-            [
-                'received_at,src,dst,pr,pkt,byt',
-                '1744732801,192.0.2.1,198.51.100.1,6,10,1000',
-                '1744733101,192.0.2.2,198.51.100.2,17,20,2000',
-            ]
-        )
-        + '\n',
-        encoding='utf-8',
-    )
-    db_path = tmp_path / 'netflow.sqlite'
+    db_path = build_two_flow_csv_db(tmp_path, pipeline_v2)
     with sqlite3.connect(db_path) as conn:
-        pipeline_v2.process_input_specs(
-            conn,
-            [
-                {
-                    'input_kind': 'csv',
-                    'path': str(csv_path),
-                    'mapping_path': str(mapping_path),
-                }
-            ],
-            max_workers=1,
-            run_maad=False,
-        )
         conn.execute(
             """
             UPDATE protocol_stats_v2

--- a/tools/netflow-db/migrate_netflow_rollups_v2.py
+++ b/tools/netflow-db/migrate_netflow_rollups_v2.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Backfill pipeline v2 NetFlow dashboard rollups."""
+
+from __future__ import annotations
+
+import argparse
+import sqlite3
+from pathlib import Path
+
+from stats_v2 import backfill_netflow_stats_aggregate_v2_rows, init_netflow_stats_v2_table
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description='Backfill netflow_stats_aggregate_v2.')
+    parser.add_argument('db_path', type=Path)
+    parser.add_argument('--analyze', action='store_true', help='Run ANALYZE after backfill.')
+    args = parser.parse_args()
+
+    if not args.db_path.is_file():
+        raise SystemExit(f'Database not found: {args.db_path}')
+
+    with sqlite3.connect(args.db_path) as conn:
+        init_netflow_stats_v2_table(conn)
+        with conn:
+            backfill_netflow_stats_aggregate_v2_rows(conn)
+            if args.analyze:
+                conn.execute('ANALYZE')
+        count = conn.execute('SELECT COUNT(*) FROM netflow_stats_aggregate_v2').fetchone()[0]
+
+    print(f'netflow_stats_aggregate_v2={count}')
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/netflow-db/stats_v2.py
+++ b/tools/netflow-db/stats_v2.py
@@ -28,6 +28,7 @@ NETFLOW_METRIC_COLUMNS = (
     'bytes_icmp',
     'bytes_other',
 )
+NETFLOW_AGGREGATE_GRANULARITIES = ('30m', '1h', '1d')
 
 
 def init_netflow_stats_v2_table(conn: sqlite3.Connection) -> None:
@@ -343,6 +344,39 @@ def insert_netflow_stats_aggregate_v2_rows(conn: sqlite3.Connection, rows: list[
             )
             for row in rows
         ],
+    )
+
+
+def backfill_netflow_stats_aggregate_v2_rows(conn: sqlite3.Connection) -> None:
+    """Backfill netflow rollups from existing 5m rows and the aggregate calendar."""
+    conn.execute(
+        """
+        INSERT OR REPLACE INTO netflow_stats_aggregate_v2 (
+            source_id, granularity, bucket_start, bucket_end, ip_version,
+            flows, flows_tcp, flows_udp, flows_icmp, flows_other,
+            packets, packets_tcp, packets_udp, packets_icmp, packets_other,
+            bytes, bytes_tcp, bytes_udp, bytes_icmp, bytes_other
+        )
+        SELECT
+            calendar.source_id,
+            calendar.granularity,
+            calendar.bucket_start,
+            calendar.bucket_end,
+            ns.ip_version,
+            SUM(ns.flows), SUM(ns.flows_tcp), SUM(ns.flows_udp), SUM(ns.flows_icmp), SUM(ns.flows_other),
+            SUM(ns.packets), SUM(ns.packets_tcp), SUM(ns.packets_udp), SUM(ns.packets_icmp), SUM(ns.packets_other),
+            SUM(ns.bytes), SUM(ns.bytes_tcp), SUM(ns.bytes_udp), SUM(ns.bytes_icmp), SUM(ns.bytes_other)
+        FROM (
+            SELECT source_id, granularity, bucket_start, bucket_end
+            FROM ip_stats_v2
+            WHERE granularity IN ('30m', '1h', '1d')
+        ) AS calendar
+        JOIN netflow_stats_v2 AS ns
+          ON ns.source_id = calendar.source_id
+         AND ns.bucket_start >= calendar.bucket_start
+         AND ns.bucket_start < calendar.bucket_end
+        GROUP BY calendar.source_id, calendar.granularity, calendar.bucket_start, calendar.bucket_end, ns.ip_version
+        """
     )
 
 

--- a/tools/netflow-db/verify_web_compatible_v2.py
+++ b/tools/netflow-db/verify_web_compatible_v2.py
@@ -161,6 +161,7 @@ def main() -> None:
     parser.add_argument('--require-data', action='store_true')
     parser.add_argument('--require-maad-data', action='store_true')
     parser.add_argument('--require-processed', action='store_true')
+    parser.add_argument('--require-rollup-parity', action='store_true')
     parser.add_argument('--require-no-raw-ip', action='store_true')
     args = parser.parse_args()
 
@@ -170,6 +171,7 @@ def main() -> None:
         require_data=args.require_data,
         require_maad_data=args.require_maad_data,
         require_processed=args.require_processed,
+        require_rollup_parity=args.require_rollup_parity,
         require_no_raw_ip=args.require_no_raw_ip,
     )
 
@@ -181,6 +183,7 @@ def verify_database(
     require_data: bool,
     require_maad_data: bool = False,
     require_processed: bool = False,
+    require_rollup_parity: bool = False,
     require_no_raw_ip: bool = False,
 ) -> None:
     if not db_path.is_file():
@@ -197,7 +200,12 @@ def verify_database(
 
         row_counts = table_row_counts(conn)
         if require_data:
-            for table_name in ('netflow_stats_v2', 'ip_stats_v2', 'protocol_stats_v2'):
+            for table_name in (
+                'netflow_stats_v2',
+                'netflow_stats_aggregate_v2',
+                'ip_stats_v2',
+                'protocol_stats_v2',
+            ):
                 if row_counts[table_name] == 0:
                     raise SystemExit(f'{table_name} has no rows.')
         if require_maad_data:
@@ -211,6 +219,9 @@ def verify_database(
             ).fetchone()[0]
             if pending_count:
                 raise SystemExit(f'processed_inputs_v2 has {pending_count} unprocessed rows.')
+
+        if require_processed or require_rollup_parity:
+            assert_netflow_rollup_parity(conn)
 
         bucket_start, bucket_end = select_query_window(conn, source)
         assert_netflow_stats_query(conn, source, bucket_start, bucket_end)
@@ -332,8 +343,9 @@ def assert_netflow_stats_query(
                SUM(bytes) AS bytes,
                SUM(CASE WHEN ip_version = 4 THEN flows ELSE 0 END) AS flowsIpv4,
                SUM(CASE WHEN ip_version = 6 THEN flows ELSE 0 END) AS flowsIpv6
-        FROM netflow_stats_v2
+        FROM netflow_stats_aggregate_v2
         WHERE source_id IN (?)
+          AND granularity = '1h'
           AND bucket_start >= ?
           AND bucket_start < ?
         GROUP BY bucketStart
@@ -344,6 +356,92 @@ def assert_netflow_stats_query(
     ).fetchone()
     if row is None or row['flows'] is None:
         raise SystemExit('Web netflow stats query returned no rows.')
+
+
+def assert_netflow_rollup_parity(conn: sqlite3.Connection) -> None:
+    """Fail when stored netflow rollups differ from raw 5m rows."""
+    mismatch_rows = conn.execute(
+        """
+        WITH expected AS (
+            SELECT
+                calendar.source_id,
+                calendar.granularity,
+                calendar.bucket_start,
+                calendar.bucket_end,
+                ns.ip_version,
+                SUM(ns.flows) AS flows,
+                SUM(ns.flows_tcp) AS flows_tcp,
+                SUM(ns.flows_udp) AS flows_udp,
+                SUM(ns.flows_icmp) AS flows_icmp,
+                SUM(ns.flows_other) AS flows_other,
+                SUM(ns.packets) AS packets,
+                SUM(ns.packets_tcp) AS packets_tcp,
+                SUM(ns.packets_udp) AS packets_udp,
+                SUM(ns.packets_icmp) AS packets_icmp,
+                SUM(ns.packets_other) AS packets_other,
+                SUM(ns.bytes) AS bytes,
+                SUM(ns.bytes_tcp) AS bytes_tcp,
+                SUM(ns.bytes_udp) AS bytes_udp,
+                SUM(ns.bytes_icmp) AS bytes_icmp,
+                SUM(ns.bytes_other) AS bytes_other
+            FROM (
+                SELECT source_id, granularity, bucket_start, bucket_end
+                FROM ip_stats_v2
+                WHERE granularity IN ('30m', '1h', '1d')
+            ) AS calendar
+            JOIN netflow_stats_v2 AS ns
+              ON ns.source_id = calendar.source_id
+             AND ns.bucket_start >= calendar.bucket_start
+             AND ns.bucket_start < calendar.bucket_end
+            GROUP BY calendar.source_id, calendar.granularity, calendar.bucket_start, calendar.bucket_end, ns.ip_version
+        ),
+        actual AS (
+            SELECT
+                source_id,
+                granularity,
+                bucket_start,
+                bucket_end,
+                ip_version,
+                flows,
+                flows_tcp,
+                flows_udp,
+                flows_icmp,
+                flows_other,
+                packets,
+                packets_tcp,
+                packets_udp,
+                packets_icmp,
+                packets_other,
+                bytes,
+                bytes_tcp,
+                bytes_udp,
+                bytes_icmp,
+                bytes_other
+            FROM netflow_stats_aggregate_v2
+        ),
+        missing_or_changed AS (
+            SELECT * FROM expected
+            EXCEPT
+            SELECT * FROM actual
+        ),
+        extra_or_changed AS (
+            SELECT * FROM actual
+            EXCEPT
+            SELECT * FROM expected
+        )
+        SELECT 'missing_or_changed' AS kind, COUNT(*) AS count FROM missing_or_changed
+        UNION ALL
+        SELECT 'extra_or_changed' AS kind, COUNT(*) AS count FROM extra_or_changed
+        """
+    ).fetchall()
+    mismatches = {row['kind']: row['count'] for row in mismatch_rows}
+    total_mismatches = sum(mismatches.values())
+    if total_mismatches:
+        raise SystemExit(
+            'netflow_stats_aggregate_v2 parity failed: '
+            f"missing_or_changed={mismatches.get('missing_or_changed', 0)}, "
+            f"extra_or_changed={mismatches.get('extra_or_changed', 0)}"
+        )
 
 
 def assert_ip_stats_query(


### PR DESCRIPTION
## Summary

Hardens the pipeline-v2 NetFlow rollup path introduced downstack.

- Adds a reusable `netflow_stats_aggregate_v2` backfill helper and CLI migration command.
- Makes `verify_web_compatible_v2.py` exercise the web-facing rollup query path.
- Requires rollup rows when `--require-data` is used.
- Checks raw 5m NetFlow rows against `netflow_stats_aggregate_v2` when processed completeness or explicit rollup parity is required.
- Adds verifier tests for empty rollups and mismatched rollup metrics.

## Why

The downstack PR routes coarse dashboard requests to `netflow_stats_aggregate_v2`. The merge/finalize gate needs to fail if that table is empty, stale, or out of sync with raw 5m rows.

## Validation

- `bun format`
- `bun lint`
- `bun typecheck`
- `./scripts/run-with-nix-if-available.sh uv run --extra test pytest tests/python/test_verify_web_compatible_v2.py tests/python/test_stats_v2.py tests/python/test_pipeline_v2.py`
- `./scripts/run-with-nix-if-available.sh uv run --extra test pytest tests/python`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added netflow rollup migration tool to backfill aggregate statistics at 30-minute, hourly, and daily granularities
  * Added `--require-rollup-parity` flag to enable verification of consistency between raw and aggregated netflow data

* **Tests**
  * Expanded coverage for netflow rollup data requirements and verification scenarios
  * Refactored test setup to eliminate configuration duplication

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flamboh/atlantis/pull/60)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->