### PR TITLE
feat: sync local dataset metadata

### DIFF
--- a/apps/web/src/lib/server/datasets.ts
+++ b/apps/web/src/lib/server/datasets.ts
@@ -12,6 +12,19 @@ type DatasetRow = {
 	sortOrder: number;
 };
 
+type LocalDatasetRow = DatasetRow & {
+	dbPath: string;
+};
+
+type SqliteClient = {
+	exec(sql: string): unknown;
+	prepare(sql: string): {
+		get(...params: QueryParam[]): unknown;
+		all(...params: QueryParam[]): unknown[];
+		run(...params: QueryParam[]): unknown;
+	};
+};
+
 export type PreparedStatement = {
 	get<T = unknown>(...params: QueryParam[]): Promise<T | undefined>;
 	all<T = unknown>(...params: QueryParam[]): Promise<T[]>;
@@ -23,33 +36,19 @@ export interface ReadonlyDatasetDb {
 	prepare(sql: string): PreparedStatement;
 }
 
-let localDbCache: ReadonlyDatasetDb | null = null;
+let localDatasetCache: LocalDatasetRow[] | null = null;
+const localDbCache = new Map<string, ReadonlyDatasetDb>();
 
 function getEnv(name: string): string | undefined {
 	return globalThis.process?.env?.[name]?.trim() || undefined;
 }
 
-async function resolveLocalSqlitePath(): Promise<string> {
-	const configured = getEnv('LOCAL_SQLITE_PATH') ?? getEnv('DATABASE_PATH');
-	if (configured) {
-		return configured;
-	}
-
-	const { existsSync } = await import('node:fs');
-	const path = await import('node:path');
-	const candidates = [
-		path.resolve(process.cwd(), 'data/ugr16/netflow.sqlite'),
-		path.resolve(process.cwd(), '../../data/ugr16/netflow.sqlite')
-	];
-
-	const found = candidates.find((candidate) => existsSync(candidate));
-	if (!found) {
-		throw new Error(
-			`Local SQLite database not found. Set LOCAL_SQLITE_PATH or create ${candidates[0]}`
-		);
-	}
-
-	return found;
+function formatLocalDate(timestampSeconds: number): string {
+	const date = new Date(timestampSeconds * 1000);
+	const year = date.getFullYear();
+	const month = `${date.getMonth() + 1}`.padStart(2, '0');
+	const day = `${date.getDate()}`.padStart(2, '0');
+	return `${year}-${month}-${day}`;
 }
 
 function makePrepared(db: ReadonlyDatasetDb, query: string): PreparedStatement {
@@ -59,31 +58,7 @@ function makePrepared(db: ReadonlyDatasetDb, query: string): PreparedStatement {
 	};
 }
 
-async function createLocalDb(): Promise<ReadonlyDatasetDb> {
-	const localPath = await resolveLocalSqlitePath();
-	const [{ drizzle }, betterSqlite3, schema] = await Promise.all([
-		import(/* @vite-ignore */ 'drizzle-orm/better-sqlite3'),
-		import(/* @vite-ignore */ 'better-sqlite3'),
-		import('$lib/server/db/schema')
-	]);
-	const sqlite = new betterSqlite3.default(localPath);
-	const drizzleDb = drizzle(sqlite, { schema });
-	const client = drizzleDb.$client;
-
-	client.exec(localSchemaSql);
-	client.exec(`
-		INSERT INTO datasets (
-			id,
-			label,
-			default_start_date,
-			source_mode,
-			discovery_mode,
-			sort_order
-		)
-		SELECT 'ugr16', 'UGR16', '2016-04-04', 'static', 'static', 0
-		WHERE NOT EXISTS (SELECT 1 FROM datasets);
-	`);
-
+function createReadonlyDb(client: SqliteClient): ReadonlyDatasetDb {
 	const db: ReadonlyDatasetDb = {
 		async get<T = unknown>(query: string, params: QueryParam[] = []) {
 			return client.prepare(query).get(...params) as T | undefined;
@@ -123,17 +98,195 @@ function createD1Db(d1: D1Database): ReadonlyDatasetDb {
 	return db;
 }
 
-export async function getDatasetDb(platform?: App.Platform): Promise<ReadonlyDatasetDb> {
-	if (getEnv('ATLANTIS_DB_DRIVER') !== 'sqlite' && platform?.env.DB) {
-		return createD1Db(platform.env.DB);
-	}
-
-	localDbCache ??= await createLocalDb();
-	return localDbCache;
+function shouldUseD1(platform?: App.Platform): boolean {
+	return getEnv('ATLANTIS_DB_DRIVER') !== 'sqlite' && Boolean(platform?.env.DB);
 }
 
-async function listDatasetRows(platform?: App.Platform): Promise<DatasetRow[]> {
-	const db = await getDatasetDb(platform);
+async function resolvePath(value: string): Promise<string> {
+	if (value === ':memory:') {
+		return value;
+	}
+
+	const path = await import('node:path');
+	return path.isAbsolute(value) ? value : path.resolve(process.cwd(), value);
+}
+
+async function discoverLocalSqlitePaths(): Promise<string[]> {
+	const configured = getEnv('LOCAL_SQLITE_PATH') ?? getEnv('DATABASE_PATH');
+	if (configured) {
+		return [await resolvePath(configured)];
+	}
+
+	const fs = await import('node:fs/promises');
+	const path = await import('node:path');
+	const roots = [path.resolve(process.cwd(), 'data'), path.resolve(process.cwd(), '../../data')];
+	const dbPaths = new Set<string>();
+
+	for (const root of roots) {
+		let entries: import('node:fs').Dirent[];
+		try {
+			entries = await fs.readdir(root, { withFileTypes: true });
+		} catch {
+			continue;
+		}
+
+		for (const entry of entries) {
+			if (!entry.isDirectory()) {
+				continue;
+			}
+			const dbPath = path.join(root, entry.name, 'netflow.sqlite');
+			try {
+				const stat = await fs.stat(dbPath);
+				if (stat.isFile()) {
+					dbPaths.add(dbPath);
+				}
+			} catch {
+				// Not every data directory is a web dataset.
+			}
+		}
+	}
+
+	if (dbPaths.size === 0) {
+		throw new Error('No local SQLite datasets found under data/*/netflow.sqlite');
+	}
+
+	return [...dbPaths].sort();
+}
+
+async function inferDatasetIdFromPath(dbPath: string): Promise<string> {
+	if (dbPath === ':memory:') {
+		return 'ugr16';
+	}
+
+	const path = await import('node:path');
+	return path.basename(path.dirname(dbPath));
+}
+
+function inferDatasetLabel(datasetId: string): string {
+	if (datasetId === 'ugr16') {
+		return 'UGR16';
+	}
+	return datasetId
+		.split(/[-_]/)
+		.filter(Boolean)
+		.map((part) => part[0]?.toUpperCase() + part.slice(1))
+		.join(' ');
+}
+
+function inferDefaultStartDate(client: SqliteClient): string {
+	const row = client
+		.prepare('SELECT MIN(bucket_start) AS minTimestamp FROM netflow_stats_v2')
+		.get() as { minTimestamp: number | null } | undefined;
+
+	if (typeof row?.minTimestamp === 'number' && Number.isFinite(row.minTimestamp)) {
+		return formatLocalDate(row.minTimestamp);
+	}
+
+	return '2025-02-01';
+}
+
+async function seedInferredDatasetMetadata(client: SqliteClient, dbPath: string): Promise<void> {
+	const row = client.prepare('SELECT COUNT(*) AS count FROM datasets').get() as
+		| { count: number }
+		| undefined;
+	if ((row?.count ?? 0) > 0) {
+		return;
+	}
+
+	const datasetId = await inferDatasetIdFromPath(dbPath);
+	client
+		.prepare(
+			`
+				INSERT INTO datasets (
+					id,
+					label,
+					default_start_date,
+					source_mode,
+					discovery_mode,
+					sort_order
+				) VALUES (?, ?, ?, 'static', 'live', 0)
+			`
+		)
+		.run(datasetId, inferDatasetLabel(datasetId), inferDefaultStartDate(client));
+}
+
+async function openLocalClient(dbPath: string): Promise<SqliteClient> {
+	const [{ drizzle }, betterSqlite3, schema] = await Promise.all([
+		import(/* @vite-ignore */ 'drizzle-orm/better-sqlite3'),
+		import(/* @vite-ignore */ 'better-sqlite3'),
+		import('$lib/server/db/schema')
+	]);
+	const sqlite = new betterSqlite3.default(dbPath);
+	const drizzleDb = drizzle(sqlite, { schema });
+	return drizzleDb.$client as SqliteClient;
+}
+
+async function createLocalDb(dbPath: string): Promise<ReadonlyDatasetDb> {
+	const client = await openLocalClient(dbPath);
+	client.exec(localSchemaSql);
+	await seedInferredDatasetMetadata(client, dbPath);
+	return createReadonlyDb(client);
+}
+
+async function getLocalDb(dbPath: string): Promise<ReadonlyDatasetDb> {
+	const existing = localDbCache.get(dbPath);
+	if (existing) {
+		return existing;
+	}
+
+	const db = await createLocalDb(dbPath);
+	localDbCache.set(dbPath, db);
+	return db;
+}
+
+async function readDatasetRowsFromDb(dbPath: string): Promise<LocalDatasetRow[]> {
+	const db = await getLocalDb(dbPath);
+	const rows = await db.all<DatasetRow>(
+		`
+			SELECT
+				id,
+				label,
+				default_start_date AS defaultStartDate,
+				discovery_mode AS discoveryMode,
+				sort_order AS sortOrder
+			FROM datasets
+			ORDER BY sort_order ASC, id ASC
+		`
+	);
+
+	return rows.map((row) => ({ ...row, dbPath }));
+}
+
+async function listLocalDatasetRows(): Promise<LocalDatasetRow[]> {
+	if (localDatasetCache) {
+		return localDatasetCache;
+	}
+
+	const dbPaths = await discoverLocalSqlitePaths();
+	const datasets = (await Promise.all(dbPaths.map(readDatasetRowsFromDb)))
+		.flat()
+		.sort((left, right) => left.sortOrder - right.sortOrder || left.id.localeCompare(right.id));
+
+	if (datasets.length === 0) {
+		throw new Error('No local datasets configured in discovered SQLite databases');
+	}
+
+	localDatasetCache = datasets;
+	return datasets;
+}
+
+async function getLocalDatasetRow(datasetId: string): Promise<LocalDatasetRow> {
+	const datasets = await listLocalDatasetRows();
+	const dataset = datasets.find((item) => item.id === datasetId);
+	if (!dataset) {
+		const available = datasets.map((item) => item.id).join(', ');
+		throw new Error(`Unknown dataset '${datasetId}'. Available datasets: ${available}`);
+	}
+	return dataset;
+}
+
+async function listD1DatasetRows(platform: App.Platform): Promise<DatasetRow[]> {
+	const db = createD1Db(platform.env.DB);
 	return db.all<DatasetRow>(
 		`
 			SELECT
@@ -146,6 +299,14 @@ async function listDatasetRows(platform?: App.Platform): Promise<DatasetRow[]> {
 			ORDER BY sort_order ASC, id ASC
 		`
 	);
+}
+
+async function listDatasetRows(platform?: App.Platform): Promise<DatasetRow[]> {
+	if (shouldUseD1(platform)) {
+		return listD1DatasetRows(platform as App.Platform);
+	}
+
+	return listLocalDatasetRows();
 }
 
 export async function listDatasets(platform?: App.Platform): Promise<DatasetRow[]> {
@@ -171,7 +332,11 @@ export async function getDatasetConfig(
 	datasetId: string,
 	platform?: App.Platform
 ): Promise<DatasetRow> {
-	const datasets = await listDatasetRows(platform);
+	if (!shouldUseD1(platform)) {
+		return getLocalDatasetRow(datasetId);
+	}
+
+	const datasets = await listD1DatasetRows(platform as App.Platform);
 	const dataset = datasets.find((item) => item.id === datasetId);
 	if (!dataset) {
 		const available = datasets.map((item) => item.id).join(', ');
@@ -186,12 +351,27 @@ export async function getDatasetLabel(datasetId: string, platform?: App.Platform
 	return dataset.label.trim() || dataset.id;
 }
 
+export async function getDatasetDb(
+	datasetOrPlatform?: string | App.Platform,
+	platform?: App.Platform
+): Promise<ReadonlyDatasetDb> {
+	const datasetId = typeof datasetOrPlatform === 'string' ? datasetOrPlatform : undefined;
+	const requestPlatform = typeof datasetOrPlatform === 'string' ? platform : datasetOrPlatform;
+
+	if (shouldUseD1(requestPlatform)) {
+		return createD1Db((requestPlatform as App.Platform).env.DB);
+	}
+
+	const resolvedDatasetId = datasetId ?? (await getDefaultDatasetId(requestPlatform));
+	const dataset = await getLocalDatasetRow(resolvedDatasetId);
+	return getLocalDb(dataset.dbPath);
+}
+
 export async function listDatasetSources(
 	datasetId: string,
 	platform?: App.Platform
 ): Promise<string[]> {
-	await getDatasetConfig(datasetId, platform);
-	const db = await getDatasetDb(platform);
+	const db = await getDatasetDb(datasetId, platform);
 	const rows = await db.all<{ sourceId: string }>(
 		`
 			SELECT DISTINCT source_id AS sourceId
@@ -204,22 +384,27 @@ export async function listDatasetSources(
 }
 
 export async function listDatasetSummaries(platform?: App.Platform): Promise<DatasetSummary[]> {
-	const db = await getDatasetDb(platform);
 	const defaultDatasetId = await getDefaultDatasetId(platform);
 	const datasets = await listDatasetRows(platform);
-	const sourceRows = await db.all<{ sourceCount: number }>(
-		'SELECT COUNT(DISTINCT source_id) AS sourceCount FROM netflow_stats_v2'
-	);
-	const sourceCount = sourceRows[0]?.sourceCount ?? 0;
 
-	return datasets.map((dataset) => ({
-		datasetId: dataset.id,
-		label: dataset.label,
-		defaultStartDate: dataset.defaultStartDate,
-		discoveryMode: dataset.discoveryMode,
-		sourceCount,
-		isDefault: dataset.id === defaultDatasetId
-	}));
+	return Promise.all(
+		datasets.map(async (dataset) => {
+			const db = await getDatasetDb(dataset.id, platform);
+			const sourceRows = await db.all<{ sourceCount: number }>(
+				'SELECT COUNT(DISTINCT source_id) AS sourceCount FROM netflow_stats_v2'
+			);
+			const sourceCount = sourceRows[0]?.sourceCount ?? 0;
+
+			return {
+				datasetId: dataset.id,
+				label: dataset.label,
+				defaultStartDate: dataset.defaultStartDate,
+				discoveryMode: dataset.discoveryMode,
+				sourceCount,
+				isDefault: dataset.id === defaultDatasetId
+			};
+		})
+	);
 }
 
 export async function getRequestedDataset(url: URL, platform?: App.Platform): Promise<string> {

--- a/apps/web/src/routes/api/ip/stats/+server.ts
+++ b/apps/web/src/routes/api/ip/stats/+server.ts
@@ -16,7 +16,7 @@ function parseGranularity(param: string | null): IpGranularity | null {
 }
 
 export const GET: RequestHandler = async ({ url, platform }) => {
-	await getRequestedDataset(url, platform);
+	const dataset = await getRequestedDataset(url, platform);
 	const routers = parseSourceIds(url.searchParams.get('routers'));
 	const granularity =
 		parseGranularity(url.searchParams.get('granularity')) ?? (IP_GRANULARITIES[2] as IpGranularity); // default 1h
@@ -36,7 +36,7 @@ export const GET: RequestHandler = async ({ url, platform }) => {
 	}
 
 	try {
-		const db = await getDatasetDb(platform);
+		const db = await getDatasetDb(dataset, platform);
 		const tableName = 'ip_stats_v2';
 		const sourceColumn = 'source_id';
 		const params = [granularity, ...routers, start, end];

--- a/apps/web/src/routes/api/netflow/files/[slug]/details/+server.ts
+++ b/apps/web/src/routes/api/netflow/files/[slug]/details/+server.ts
@@ -122,7 +122,7 @@ function buildIpCounts(ipv4Count: number | null, ipv6Count: number | null): File
 
 export const GET: RequestHandler = async ({ params, url, platform }) => {
 	const { slug } = params;
-	await getDatasetFromRequest(url, platform);
+	const dataset = await getDatasetFromRequest(url, platform);
 
 	if (!slug || slug.length !== 12 || !/^\d{12}$/.test(slug)) {
 		return json({ error: 'Invalid slug format' }, { status: 400 });
@@ -134,7 +134,7 @@ export const GET: RequestHandler = async ({ params, url, platform }) => {
 	}
 
 	try {
-		const db = await getDb(platform);
+		const db = await getDb(dataset, platform);
 		const rows = await db.all<FileDetailsRow>(
 			`SELECT
 				ns.*,

--- a/apps/web/src/routes/api/netflow/files/[slug]/ip-counts/+server.ts
+++ b/apps/web/src/routes/api/netflow/files/[slug]/ip-counts/+server.ts
@@ -13,7 +13,7 @@ type IpCountRow = {
 
 export const GET: RequestHandler = async ({ params, url, platform }) => {
 	const { slug } = params;
-	await getDatasetFromRequest(url, platform);
+	const dataset = await getDatasetFromRequest(url, platform);
 	const router = url.searchParams.get('router');
 	const sourceParam = url.searchParams.get('source');
 
@@ -40,7 +40,7 @@ export const GET: RequestHandler = async ({ params, url, platform }) => {
 	}
 
 	try {
-		const db = await getDb(platform);
+		const db = await getDb(dataset, platform);
 		const row = await db.get<IpCountRow>(
 			`SELECT
 				sa_ipv4_count AS saIpv4Count,

--- a/apps/web/src/routes/api/netflow/files/[slug]/spectrum/+server.ts
+++ b/apps/web/src/routes/api/netflow/files/[slug]/spectrum/+server.ts
@@ -12,7 +12,7 @@ type SpectrumRow = {
 
 export const GET: RequestHandler = async ({ params, url, platform }) => {
 	const { slug } = params;
-	await getDatasetFromRequest(url, platform);
+	const dataset = await getDatasetFromRequest(url, platform);
 	const router = url.searchParams.get('router');
 	const sourceParam = url.searchParams.get('source');
 
@@ -39,7 +39,7 @@ export const GET: RequestHandler = async ({ params, url, platform }) => {
 	}
 
 	try {
-		const db = await getDb(platform);
+		const db = await getDb(dataset, platform);
 		const row = await db.get<SpectrumRow>(
 			`SELECT
 				spectrum_json_sa AS spectrumJsonSa,

--- a/apps/web/src/routes/api/netflow/files/[slug]/structure/+server.ts
+++ b/apps/web/src/routes/api/netflow/files/[slug]/structure/+server.ts
@@ -13,7 +13,7 @@ type StructureRow = {
 
 export const GET: RequestHandler = async ({ params, url, platform }) => {
 	const { slug } = params;
-	await getDatasetFromRequest(url, platform);
+	const dataset = await getDatasetFromRequest(url, platform);
 	const router = url.searchParams.get('router');
 	const sourceParam = url.searchParams.get('source');
 
@@ -40,7 +40,7 @@ export const GET: RequestHandler = async ({ params, url, platform }) => {
 	}
 
 	try {
-		const db = await getDb(platform);
+		const db = await getDb(dataset, platform);
 		const row = await db.get<StructureRow>(
 			`SELECT
 				structure_json_sa AS structureJsonSa,

--- a/apps/web/src/routes/api/netflow/files/[slug]/utils.ts
+++ b/apps/web/src/routes/api/netflow/files/[slug]/utils.ts
@@ -6,8 +6,8 @@ export interface NetflowRecord {
 	input_locator: string;
 }
 
-export function getDb(platform?: App.Platform) {
-	return getDatasetDb(platform);
+export function getDb(datasetOrPlatform?: string | App.Platform, platform?: App.Platform) {
+	return getDatasetDb(datasetOrPlatform, platform);
 }
 
 export function slugToBucketStart(slug: string): number | null {

--- a/apps/web/src/routes/api/netflow/spectrum-stats/+server.ts
+++ b/apps/web/src/routes/api/netflow/spectrum-stats/+server.ts
@@ -16,7 +16,7 @@ function parseGranularity(param: string | null): IpGranularity | null {
 }
 
 export const GET: RequestHandler = async ({ url, platform }) => {
-	await getRequestedDataset(url, platform);
+	const dataset = await getRequestedDataset(url, platform);
 	const routers = parseSourceIds(url.searchParams.get('routers'));
 	const granularity =
 		parseGranularity(url.searchParams.get('granularity')) ?? (IP_GRANULARITIES[2] as IpGranularity); // default 1h
@@ -36,7 +36,7 @@ export const GET: RequestHandler = async ({ url, platform }) => {
 	}
 
 	try {
-		const db = await getDatasetDb(platform);
+		const db = await getDatasetDb(dataset, platform);
 		const tableName = 'spectrum_stats_v2';
 		const sourceColumn = 'source_id';
 		const params = [granularity, ...routers, start, end];

--- a/apps/web/src/routes/api/netflow/stats/+server.ts
+++ b/apps/web/src/routes/api/netflow/stats/+server.ts
@@ -97,7 +97,7 @@ function normalizeRow(row: Record<string, number | null>): NetflowStatsResult {
 }
 
 export const GET: RequestHandler = async ({ url, platform }) => {
-	await getRequestedDataset(url, platform);
+	const dataset = await getRequestedDataset(url, platform);
 	const startDate = url.searchParams.get('startDate') || '';
 	const endDate = url.searchParams.get('endDate') || '';
 	const groupBy = url.searchParams.get('groupBy') || 'date';
@@ -118,7 +118,7 @@ export const GET: RequestHandler = async ({ url, platform }) => {
 	}
 
 	try {
-		const db = await getDatasetDb(platform);
+		const db = await getDatasetDb(dataset, platform);
 		const granularity = groupByToGranularity(groupBy);
 		const useAggregate = granularity !== '5m';
 		const timeColumn = 'bucket_start';

--- a/apps/web/src/routes/api/netflow/structure-stats/+server.ts
+++ b/apps/web/src/routes/api/netflow/structure-stats/+server.ts
@@ -25,7 +25,7 @@ function parseGranularity(param: string | null): IpGranularity | null {
 }
 
 export const GET: RequestHandler = async ({ url, platform }) => {
-	await getRequestedDataset(url, platform);
+	const dataset = await getRequestedDataset(url, platform);
 	const routers = parseSourceIds(url.searchParams.get('routers'));
 	const granularity =
 		parseGranularity(url.searchParams.get('granularity')) ?? (IP_GRANULARITIES[2] as IpGranularity); // default 1h
@@ -45,7 +45,7 @@ export const GET: RequestHandler = async ({ url, platform }) => {
 	}
 
 	try {
-		const db = await getDatasetDb(platform);
+		const db = await getDatasetDb(dataset, platform);
 		const tableName = 'structure_stats_v2';
 		const sourceColumn = 'source_id';
 		const params = [granularity, ...routers, start, end];

--- a/apps/web/src/routes/api/protocol/stats/+server.ts
+++ b/apps/web/src/routes/api/protocol/stats/+server.ts
@@ -39,8 +39,8 @@ export const GET: RequestHandler = async ({ url, platform }) => {
 	}
 
 	try {
-		await getRequestedDataset(url, platform);
-		const db = await getDatasetDb(platform);
+		const dataset = await getRequestedDataset(url, platform);
+		const db = await getDatasetDb(dataset, platform);
 		const tableName = 'protocol_stats_v2';
 		const sourceColumn = 'source_id';
 		const params = [granularity, ...routers, start, end];

--- a/apps/web/tests/lib/server/datasets.test.ts
+++ b/apps/web/tests/lib/server/datasets.test.ts
@@ -1,5 +1,6 @@
 import os from 'os';
 import path from 'path';
+import fs from 'fs';
 import { spawnSync } from 'child_process';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -48,7 +49,10 @@ function createSqliteFixture(): string {
 }
 
 describe('dataset server helpers', () => {
+	const originalCwd = process.cwd();
+
 	afterEach(() => {
+		process.chdir(originalCwd);
 		vi.unstubAllEnvs();
 	});
 
@@ -81,4 +85,73 @@ describe('dataset server helpers', () => {
 
 		await expect(datasets.getDatasetConfig('missing')).rejects.toThrow(/Unknown dataset 'missing'/);
 	});
+
+	it('discovers local sqlite datasets from data directories', async () => {
+		const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'datasets-scan-'));
+		const alphaDir = path.join(workspace, 'data', 'alpha');
+		const betaDir = path.join(workspace, 'data', 'beta');
+		fs.mkdirSync(alphaDir, { recursive: true });
+		fs.mkdirSync(betaDir, { recursive: true });
+		seedDatasetDb(path.join(alphaDir, 'netflow.sqlite'), 'alpha', 'Alpha', 'router-a');
+		seedDatasetDb(path.join(betaDir, 'netflow.sqlite'), 'beta', 'Beta', 'router-b');
+		process.chdir(workspace);
+
+		const datasets = await loadDatasetsModule();
+
+		await expect(datasets.listDatasetSummaries()).resolves.toEqual([
+			{
+				datasetId: 'alpha',
+				label: 'Alpha',
+				defaultStartDate: '2025-03-01',
+				discoveryMode: 'static',
+				sourceCount: 1,
+				isDefault: true
+			},
+			{
+				datasetId: 'beta',
+				label: 'Beta',
+				defaultStartDate: '2025-03-01',
+				discoveryMode: 'static',
+				sourceCount: 1,
+				isDefault: false
+			}
+		]);
+		await expect(datasets.listDatasetSources('beta')).resolves.toEqual(['router-b']);
+	});
 });
+
+function seedDatasetDb(dbPath: string, datasetId: string, label: string, sourceId: string): void {
+	const seedResult = spawnSync(
+		'sqlite3',
+		[
+			dbPath,
+			`
+				CREATE TABLE datasets (
+					id TEXT PRIMARY KEY NOT NULL,
+					label TEXT NOT NULL,
+					default_start_date TEXT NOT NULL,
+					source_mode TEXT DEFAULT 'static' NOT NULL,
+					discovery_mode TEXT DEFAULT 'static' NOT NULL,
+					sort_order INTEGER DEFAULT 0 NOT NULL
+				);
+				CREATE TABLE netflow_stats_v2 (
+					source_id TEXT NOT NULL,
+					bucket_start INTEGER NOT NULL,
+					ip_version INTEGER NOT NULL
+				);
+				INSERT INTO datasets (
+					id,
+					label,
+					default_start_date,
+					source_mode,
+					discovery_mode,
+					sort_order
+				) VALUES ('${datasetId}', '${label}', '2025-03-01', 'static', 'static', 0);
+				INSERT INTO netflow_stats_v2 (source_id, bucket_start, ip_version)
+				VALUES ('${sourceId}', 1740823200, 4);
+			`
+		],
+		{ encoding: 'utf-8' }
+	);
+	expect(seedResult.status, seedResult.stderr).toBe(0);
+}

--- a/docs/datasets-json.md
+++ b/docs/datasets-json.md
@@ -1,6 +1,8 @@
 # `datasets.json` setup
 
-`datasets.json` defines which NetFlow datasets the pipeline and web app know about.
+`datasets.json` defines local pipeline inputs: roots, source discovery, and
+SQLite output paths. The web app does not read this file directly; it reads the
+`datasets` table inside SQLite/D1.
 
 The file is not meant to be committed with machine-specific paths. Start from
 `datasets.json.example` and create your own local `datasets.json` in the repo root.
@@ -10,7 +12,8 @@ The file is not meant to be committed with machine-specific paths. Start from
 1. Copy `datasets.json.example` to `datasets.json`
 2. Update the dataset paths for your machine
 3. Make sure each dataset has a unique `dataset_id`
-4. Set `DEFAULT_DATASET` in `.env` if you want one dataset to be used by default
+4. Run the pipeline; new v2 SQLite databases are seeded with a `datasets` row
+5. Set `DEFAULT_DATASET` in `.env` if you want one dataset to be used by default
 
 ## Example
 
@@ -43,3 +46,5 @@ The file is not meant to be committed with machine-specific paths. Start from
 - `db_path` can be relative to the repo root
 - `root_path` is usually absolute
 - if you want to store the config somewhere else, point `DATASETS_CONFIG_PATH` in `.env` at that file
+- local web discovery scans `data/*/netflow.sqlite` and reads each database's
+  `datasets` table

--- a/docs/pipeline-v2.md
+++ b/docs/pipeline-v2.md
@@ -12,6 +12,7 @@ v2 ingest contract, not an optional side path.
 
 Pipeline v2 currently writes:
 
+- `datasets`
 - `processed_inputs_v2`
 - `netflow_stats_v2`
 - `ip_stats_v2`
@@ -46,6 +47,10 @@ pipeline processes this tree one calendar day at a time into
 `./data/<dataset>-v2/netflow.sqlite`, keeping memory bounded. Reruns skip days
 where every discovered nfcapd file is already marked `processed`; partial days
 are rebuilt as a full day so aggregate rows stay coherent.
+
+The generated SQLite database also gets a `datasets` metadata row copied from
+`datasets.json`. Local web discovery scans `data/*/netflow.sqlite`, reads those
+metadata rows, and opens the selected dataset's SQLite file for API queries.
 
 Explicit json configs are still supported for csv inputs and unusual file
 layouts:

--- a/tests/python/test_pipeline_v2.py
+++ b/tests/python/test_pipeline_v2.py
@@ -665,6 +665,60 @@ def test_csv_tree_discovers_ugr16_archives_and_extracted_files(monkeypatch, tmp_
     ]
 
 
+def test_process_pipeline_v2_config_writes_dataset_metadata() -> None:
+    pipeline_v2, _ = load_modules()
+    conn = sqlite3.connect(':memory:')
+
+    pipeline_v2.process_pipeline_v2_config(
+        conn,
+        {
+            'datasets': [
+                {
+                    'dataset_id': 'alpha',
+                    'label': 'Alpha Dataset',
+                    'default_start_date': '2025-03-01',
+                    'source_mode': 'subdirs',
+                    'discovery_mode': 'live',
+                    'sort_order': 3,
+                }
+            ],
+            'inputs': [],
+        },
+    )
+
+    assert conn.execute(
+        """
+        SELECT id, label, default_start_date, source_mode, discovery_mode, sort_order
+        FROM datasets
+        """
+    ).fetchall() == [('alpha', 'Alpha Dataset', '2025-03-01', 'subdirs', 'live', 3)]
+
+
+def test_build_dataset_tree_config_includes_dataset_metadata(monkeypatch, tmp_path: Path) -> None:
+    pipeline_v2, _ = load_modules()
+    common = importlib.import_module('common')
+    dataset = {
+        'dataset_id': 'alpha',
+        'label': 'Alpha Dataset',
+        'root_path': str(tmp_path / 'raw'),
+        'db_path': str(tmp_path / 'netflow.sqlite'),
+        'default_start_date': '2025-03-01',
+        'source_mode': 'subdirs',
+        'discovery_mode': 'live',
+        'source_ids': ['router-a'],
+    }
+    monkeypatch.setattr(common, 'get_dataset_config', lambda dataset_id: dataset)
+    monkeypatch.setattr(common, 'list_dataset_sources', lambda dataset_id: ['router-a'])
+
+    config = pipeline_v2.build_dataset_tree_config(
+        dataset_id='alpha',
+        start_date='2025-03-01',
+        database_path=tmp_path / 'out.sqlite',
+    )
+
+    assert config['datasets'] == [dataset]
+
+
 def test_discover_nfcapd_tree_specs_uses_canonical_layout(tmp_path: Path) -> None:
     pipeline_v2, _ = load_modules()
     root = tmp_path / 'uoregon'

--- a/tools/netflow-db/datasets_metadata.py
+++ b/tools/netflow-db/datasets_metadata.py
@@ -1,0 +1,55 @@
+"""Dataset metadata table shared by pipeline output and the web app."""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any
+
+
+def init_datasets_table(conn: sqlite3.Connection) -> None:
+    """Create the dataset metadata table if it does not exist."""
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS datasets (
+            id TEXT PRIMARY KEY NOT NULL,
+            label TEXT NOT NULL,
+            default_start_date TEXT NOT NULL,
+            source_mode TEXT NOT NULL DEFAULT 'static',
+            discovery_mode TEXT NOT NULL DEFAULT 'static',
+            sort_order INTEGER NOT NULL DEFAULT 0
+        )
+        """
+    )
+    conn.commit()
+
+
+def upsert_dataset_metadata(conn: sqlite3.Connection, dataset: dict[str, Any]) -> None:
+    """Insert or update one dataset metadata row."""
+    init_datasets_table(conn)
+    dataset_id = str(dataset['dataset_id']).strip()
+    label = str(dataset.get('label') or dataset_id)
+    default_start_date = str(dataset.get('default_start_date') or '2025-02-01').strip()
+    source_mode = str(dataset.get('source_mode') or 'static').strip()
+    discovery_mode = str(dataset.get('discovery_mode') or 'static').strip()
+    sort_order = int(dataset.get('sort_order') or 0)
+
+    conn.execute(
+        """
+        INSERT INTO datasets (
+            id,
+            label,
+            default_start_date,
+            source_mode,
+            discovery_mode,
+            sort_order
+        ) VALUES (?, ?, ?, ?, ?, ?)
+        ON CONFLICT(id) DO UPDATE SET
+            label = excluded.label,
+            default_start_date = excluded.default_start_date,
+            source_mode = excluded.source_mode,
+            discovery_mode = excluded.discovery_mode,
+            sort_order = excluded.sort_order
+        """,
+        (dataset_id, label, default_start_date, source_mode, discovery_mode, sort_order),
+    )
+    conn.commit()

--- a/tools/netflow-db/pipeline_v2.py
+++ b/tools/netflow-db/pipeline_v2.py
@@ -45,6 +45,7 @@ from csv_inputs_v2 import (
     iter_headerless_csv_values,
     is_tar_archive,
 )
+from datasets_metadata import init_datasets_table, upsert_dataset_metadata
 from maad_v2 import (
     MaadTimeoutError,
     MaadJsonResult,
@@ -258,6 +259,10 @@ def load_pipeline_v2_config(path: str | Path) -> dict:
 
 def process_pipeline_v2_config(conn: sqlite3.Connection, config: dict) -> None:
     """Process a v2 config, including canonical nfcapd tree inputs."""
+    init_datasets_table(conn)
+    for dataset in config.get('datasets', []):
+        upsert_dataset_metadata(conn, dataset)
+
     maad_bin = config.get('maad_bin', DEFAULT_MAAD_BIN)
     maad_backend = str(config.get('maad_backend', 'subprocess'))
     maad_workers = int(config.get('maad_workers', 1))
@@ -503,6 +508,7 @@ def build_dataset_tree_config(
         'database_path': str(db_path),
         'maad_bin': str(maad_bin),
         'max_workers': max_workers,
+        'datasets': [dataset],
         'inputs': [tree_input],
     }
 


### PR DESCRIPTION
## Summary
- seed pipeline v2 SQLite outputs with dataset metadata copied from datasets.json
- make local web discovery scan data/*/netflow.sqlite and route API queries to the selected local SQLite database
- document datasets.json as pipeline input and add local/D1 metadata coverage tests

## Verification
- bun format
- bun lint
- bun typecheck
- bun run --cwd apps/web test
- bun run --cwd apps/web build
- ./scripts/run-with-nix-if-available.sh uv run --extra test pytest tests/python/test_pipeline_v2.py tests/python/test_common.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  - Multi-dataset support: The application now dynamically supports both cloud-backed and locally hosted SQLite datasets.
  - Automatic local dataset discovery from SQLite files with metadata inference and caching.
  - Dataset metadata table for managing dataset labels, defaults, and configuration.

* **Bug Fixes**
  - API endpoints now properly resolve and use the requested dataset instead of defaulting to the global setting.

* **Documentation**
  - Updated guides to clarify how datasets are discovered and stored locally.

* **Tests**
  - Added tests for local dataset discovery and metadata handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flamboh/atlantis/pull/64)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->