### PR TITLE
perf(netflow-db): stream nfcapd aggregates and zero-fill gaps

### DIFF
--- a/docs/pipeline-v2.md
+++ b/docs/pipeline-v2.md
@@ -48,6 +48,18 @@ pipeline processes this tree one calendar day at a time into
 where every discovered nfcapd file is already marked `processed`; partial days
 are rebuilt as a full day so aggregate rows stay coherent.
 
+Native `nfcapd` buckets are written as each worker payload completes. The
+pipeline keeps only coarser aggregate union state after each 5-minute payload is
+written, instead of retaining every raw bucket address list through the full day.
+
+By default, `nfcapd_tree` also materializes bounded gaps as zero buckets. For
+each source, the pipeline fills missing 5-minute buckets only between the first
+and last real `nfcapd` file discovered for that source. Gap records use
+synthetic `gap://nfcapd/<source>/<YYYYMMDDHHMM>` locators in
+`processed_inputs_v2` while keeping `input_kind = 'nfcapd'`, so existing
+databases can be migrated in place. Set `"zero_fill_gaps": false` on an
+`nfcapd_tree` input to process only files that exist on disk.
+
 The generated SQLite database also gets a `datasets` metadata row copied from
 `datasets.json`. Local web discovery scans `data/*/netflow.sqlite`, reads those
 metadata rows, and opens the selected dataset's SQLite file for API queries.
@@ -275,21 +287,41 @@ CSV files and tar archives such as `*_csv.tar.gz`.
 
 ## NFDUMP Contract
 
-The current `nfcapd` adapter calls `nfdump` with a fixed csv order:
+The current `nfcapd` adapter uses grouped `nfdump` queries instead of
+materializing every flow row in Python. Each 5-minute file uses one grouped
+address query plus one grouped protocol query per IP family:
 
 ```bash
-nfdump -r <file> -q -o 'csv:%trr,%ter,%tsr,%sa,%da,%sp,%dp,%pr,%pkt,%byt,%stos,%dtos' ipv4
-nfdump -r <file> -q -o 'csv:%trr,%ter,%tsr,%sa,%da,%sp,%dp,%pr,%pkt,%byt,%stos,%dtos' ipv6 -6
+nfdump -r <file> -q -a -A srcip,dstip -o 'fmt:%sa,%da'
+nfdump -r <file> -q -a -A proto -o csv ipv4 -N
+nfdump -r <file> -q -a -A proto -o csv ipv6 -6 -N
 ```
 
-The v2 adapter treats these fields as:
+Use `tools/netflow-db/benchmark_nfcapd_v2.py` to capture repeatable slice
+timings. Payload mode isolates nfdump payload construction:
 
-- `time_received = %trr`
-- `time_end = %ter`
-- `time_start = %tsr`
+```bash
+python tools/netflow-db/benchmark_nfcapd_v2.py \
+  --root /research/obo/netflow_datasets/uoregon \
+  --source oh_ir1_gw \
+  --day 2025-04-15 \
+  --limit 24
+```
 
-The raw epoch forms are required because `%tr`, `%te`, and `%ts` emit formatted
-timestamps in nfdump CSV output.
+Pipeline mode includes SQLite writes and aggregate row generation:
+
+```bash
+python tools/netflow-db/benchmark_nfcapd_v2.py \
+  --mode pipeline \
+  --root /research/obo/netflow_datasets/uoregon \
+  --source oh_ir1_gw \
+  --day 2025-04-15 \
+  --limit 24 \
+  --max-workers 1
+```
+
+Add `--legacy-address-split` to either benchmark command to compare against the
+previous two-command IPv4/IPv6 address extraction shape.
 
 nfdump can emit ICMP type/code values such as `3.1` in port fields. Pipeline v2
 normalizes decimal pseudo-ports to `0` because they are not transport ports.

--- a/tests/python/test_extract_ml_window.py
+++ b/tests/python/test_extract_ml_window.py
@@ -30,10 +30,57 @@ def make_source_db(path: Path) -> sqlite3.Connection:
     return conn
 
 
+def make_v2_source_db(path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    conn.execute(
+        'CREATE TABLE datasets (id TEXT PRIMARY KEY NOT NULL, label TEXT NOT NULL, default_start_date TEXT NOT NULL)'
+    )
+    conn.execute(
+        """
+        CREATE TABLE netflow_stats_v2 (
+            source_id TEXT NOT NULL,
+            bucket_start INTEGER NOT NULL,
+            bucket_end INTEGER NOT NULL,
+            ip_version INTEGER NOT NULL,
+            flows INTEGER NOT NULL,
+            PRIMARY KEY (source_id, bucket_start, ip_version)
+        ) WITHOUT ROWID
+        """
+    )
+    conn.execute('CREATE INDEX idx_netflow_stats_v2_bucket_source ON netflow_stats_v2(bucket_start, source_id, ip_version)')
+    conn.execute('INSERT INTO datasets (id, label, default_start_date) VALUES (?, ?, ?)', ('uoregon', 'UONet-in v2', '2025-02-01'))
+    conn.executemany(
+        'INSERT INTO netflow_stats_v2 (source_id, bucket_start, bucket_end, ip_version, flows) VALUES (?, ?, ?, ?, ?)',
+        [
+            ('r1', 100, 400, 4, 10),
+            ('r1', 200, 500, 6, 20),
+            ('r2', 200, 500, 4, 30),
+            ('r1', 500, 800, 4, 50),
+        ],
+    )
+    conn.commit()
+    return conn
+
+
 def test_compute_window_rejects_reversed_dates() -> None:
     module = load_module()
-    with pytest.raises(SystemExit, match='--end-inclusive must be on or after --start'):
-        module.compute_window('2025-03-02', '2025-03-01')
+    with pytest.raises(SystemExit, match='--end-exclusive must be after --start'):
+        module.compute_window('2025-03-02', '2025-03-02', 'America/Los_Angeles')
+
+
+def test_compute_window_uses_exclusive_local_date_boundary() -> None:
+    module = load_module()
+    start_dt, end_dt, start_ts, end_ts = module.compute_window(
+        '2025-05-01',
+        '2026-05-01',
+        'America/Los_Angeles',
+    )
+
+    assert start_dt.strftime('%Y-%m-%d') == '2025-05-01'
+    assert end_dt.strftime('%Y-%m-%d') == '2026-05-01'
+    assert start_ts == 1746082800
+    assert end_ts == 1777618800
 
 
 def test_copy_table_to_sqlite_preserves_schema_and_rows(tmp_path: Path) -> None:
@@ -61,6 +108,62 @@ def test_copy_table_to_sqlite_preserves_schema_and_rows(tmp_path: Path) -> None:
     assert [tuple(row) for row in rows] == [(200, 'r1', 20), (400, 'r2', 40)]
 
 
+def test_copy_v2_table_filters_by_source_id(tmp_path: Path) -> None:
+    module = load_module()
+    source_path = tmp_path / 'source.sqlite'
+    dest_path = tmp_path / 'dest.sqlite'
+    source_conn = make_v2_source_db(source_path)
+    dest_conn = module.connect_db(dest_path)
+    config = module.TABLE_CONFIG['netflow_stats_v2']
+    extra_where, extra_params = module.build_table_filters(
+        source_id='r1',
+        granularities=None,
+        config=config,
+    )
+
+    module.create_sqlite_table(source_conn, dest_conn, 'netflow_stats_v2')
+    inserted = module.copy_table_to_sqlite(
+        source_conn,
+        dest_conn,
+        'netflow_stats_v2',
+        config['time_column'],
+        150,
+        500,
+        2,
+        extra_where=extra_where,
+        extra_params=extra_params,
+    )
+
+    assert inserted == 1
+    rows = dest_conn.execute(
+        'SELECT source_id, bucket_start, ip_version, flows FROM netflow_stats_v2'
+    ).fetchall()
+    assert [tuple(row) for row in rows] == [('r1', 200, 6, 20)]
+
+
+def test_copy_static_metadata_table_without_time_filter(tmp_path: Path) -> None:
+    module = load_module()
+    source_path = tmp_path / 'source.sqlite'
+    dest_path = tmp_path / 'dest.sqlite'
+    source_conn = make_v2_source_db(source_path)
+    dest_conn = module.connect_db(dest_path)
+
+    module.create_sqlite_table(source_conn, dest_conn, 'datasets')
+    inserted = module.copy_table_to_sqlite(
+        source_conn,
+        dest_conn,
+        'datasets',
+        None,
+        150,
+        500,
+        2,
+    )
+
+    assert inserted == 1
+    row = dest_conn.execute('SELECT id, label, default_start_date FROM datasets').fetchone()
+    assert tuple(row) == ('uoregon', 'UONet-in v2', '2025-02-01')
+
+
 def test_collect_table_summary_and_manifest(tmp_path: Path) -> None:
     module = load_module()
     source_conn = make_source_db(tmp_path / 'summary.sqlite')
@@ -73,11 +176,15 @@ def test_collect_table_summary_and_manifest(tmp_path: Path) -> None:
         end_exclusive_dt=datetime(2025, 6, 8),
         start_ts=123,
         end_ts=456,
+        timezone='America/Los_Angeles',
+        source_id=None,
+        granularities=None,
         tables={'netflow_stats': summary},
     )
     manifest_path = module.write_manifest(tmp_path, manifest)
 
     assert summary == {'row_count': 2, 'min_time': 100, 'max_time': 200}
-    assert manifest['end_inclusive_date'] == '2025-06-07'
+    assert manifest['end_exclusive_date'] == '2025-06-08'
+    assert manifest['timezone'] == 'America/Los_Angeles'
     assert manifest_path.read_text().endswith('\n')
     assert '"row_count": 2' in manifest_path.read_text()

--- a/tests/python/test_nfdump_stats_v2.py
+++ b/tests/python/test_nfdump_stats_v2.py
@@ -12,8 +12,10 @@ def load_module():
 def test_build_nfcapd_bucket_payload_uses_grouped_nfdump_outputs(monkeypatch) -> None:
     monkeypatch.setenv('NETFLOW_TIMEZONE', 'America/Los_Angeles')
     module = load_module()
+    commands = []
 
     def fake_run(command, capture_output, text, timeout):
+        commands.append(command)
         assert capture_output is True
         assert text is True
         assert timeout == 300
@@ -39,18 +41,17 @@ def test_build_nfcapd_bucket_payload_uses_grouped_nfdump_outputs(monkeypatch) ->
                 ),
                 stderr='',
             )
-        if '-A srcip,dstip' in command_text and 'ipv4' in command:
+        if '-A srcip,dstip' in command_text:
+            assert 'ipv4' not in command
+            assert 'ipv6' not in command
             return subprocess.CompletedProcess(
                 command,
                 0,
-                stdout='192.0.2.1,198.51.100.1\n192.0.2.2,198.51.100.2\n',
-                stderr='',
-            )
-        if '-A srcip,dstip' in command_text and 'ipv6' in command:
-            return subprocess.CompletedProcess(
-                command,
-                0,
-                stdout='2001:db8::1,2001:db8::2\n',
+                stdout=(
+                    '192.0.2.1,198.51.100.1\n'
+                    '192.0.2.2,198.51.100.2\n'
+                    '2001:db8::1,2001:db8::2\n'
+                ),
                 stderr='',
             )
         raise AssertionError(f'unexpected command: {command}')
@@ -117,6 +118,7 @@ def test_build_nfcapd_bucket_payload_uses_grouped_nfdump_outputs(monkeypatch) ->
     assert payload['ip_row']['da_ipv6_count'] == 1
     assert payload['protocol_row']['protocols_list_ipv4'] == '17,6'
     assert payload['raw_bucket']['maad_source_ipv4'] == ['192.0.2.1', '192.0.2.2']
+    assert len(commands) == 3
 
 
 def test_parse_nfcapd_bucket_start_uses_first_fold_for_ambiguous_fall_back(monkeypatch) -> None:
@@ -134,6 +136,34 @@ def test_parse_nfcapd_bucket_start_rejects_tmp_suffix() -> None:
 
     with pytest.raises(ValueError, match='Invalid nfcapd filename'):
         module.parse_nfcapd_bucket_start('/captures/oh_ir1_gw/2025/11/02/nfcapd.202511020115.tmp')
+
+
+def test_read_address_sets_by_version_uses_fast_ipv4_path(monkeypatch) -> None:
+    module = load_module()
+
+    def fake_run(command, capture_output, text, timeout):
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout=(
+                '192.0.2.1,198.51.100.1\n'
+                'source,destination\n'
+                '2001:0db8::1,2001:0db8::2\n'
+                'not-ip,198.51.100.2\n'
+            ),
+            stderr='',
+        )
+
+    monkeypatch.setattr(module.subprocess, 'run', fake_run)
+
+    source_ipv4, destination_ipv4, source_ipv6, destination_ipv6 = module.read_address_sets_by_version(
+        '/captures/nfcapd.202508190500'
+    )
+
+    assert source_ipv4 == {'192.0.2.1'}
+    assert destination_ipv4 == {'198.51.100.1'}
+    assert source_ipv6 == {'2001:db8::1'}
+    assert destination_ipv6 == {'2001:db8::2'}
 
 
 def test_read_protocol_counters_skips_sparse_nfdump_rows(monkeypatch, caplog) -> None:

--- a/tests/python/test_nfdump_stats_v2.py
+++ b/tests/python/test_nfdump_stats_v2.py
@@ -1,6 +1,8 @@
 import importlib
 import subprocess
 
+import pytest
+
 
 def load_module():
     nfdump_stats_v2 = importlib.import_module('nfdump_stats_v2')
@@ -125,6 +127,13 @@ def test_parse_nfcapd_bucket_start_uses_first_fold_for_ambiguous_fall_back(monke
         module.parse_nfcapd_bucket_start('/captures/oh_ir1_gw/2025/11/02/nfcapd.202511020115')
         == 1762071300
     )
+
+
+def test_parse_nfcapd_bucket_start_rejects_tmp_suffix() -> None:
+    module = load_module()
+
+    with pytest.raises(ValueError, match='Invalid nfcapd filename'):
+        module.parse_nfcapd_bucket_start('/captures/oh_ir1_gw/2025/11/02/nfcapd.202511020115.tmp')
 
 
 def test_read_protocol_counters_skips_sparse_nfdump_rows(monkeypatch, caplog) -> None:

--- a/tests/python/test_pipeline_v2.py
+++ b/tests/python/test_pipeline_v2.py
@@ -728,7 +728,8 @@ def test_discover_nfcapd_tree_specs_uses_canonical_layout(tmp_path: Path) -> Non
         root / 'oh_ir1_gw' / '2025' / '02' / '01' / 'nfcapd.202502010000',
     ]
     ignored = root / 'oh_ir1_gw' / '2025' / '02' / '02' / 'nfcapd.202502020000'
-    for path in [*valid, ignored]:
+    tmp_file = root / 'oh_ir1_gw' / '2025' / '02' / '01' / 'nfcapd.202502010005.tmp'
+    for path in [*valid, ignored, tmp_file]:
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text('', encoding='utf-8')
 

--- a/tests/python/test_pipeline_v2.py
+++ b/tests/python/test_pipeline_v2.py
@@ -318,6 +318,11 @@ def test_process_input_specs_uses_nfdump_adapter_for_nfcapd(monkeypatch) -> None
         }
 
     monkeypatch.setattr(pipeline_v2, 'build_nfcapd_bucket_payload', fake_build_nfcapd_bucket_payload)
+    monkeypatch.setattr(
+        pipeline_v2,
+        'write_aggregate_rows',
+        lambda *args, **kwargs: pytest.fail('nfcapd inputs should use streaming aggregate state'),
+    )
 
     pipeline_v2.process_input_specs(
         conn,
@@ -337,6 +342,13 @@ def test_process_input_specs_uses_nfdump_adapter_for_nfcapd(monkeypatch) -> None
     processed_inputs = conn.execute(
         'SELECT input_kind, input_locator, source_id, bucket_start, status FROM processed_inputs_v2'
     ).fetchall()
+    aggregate_netflow = conn.execute(
+        """
+        SELECT granularity, ip_version, flows, packets, bytes
+        FROM netflow_stats_aggregate_v2
+        ORDER BY granularity, ip_version
+        """
+    ).fetchall()
 
     assert netflow == [
         ('oh_ir1_gw', 1744733100, 4, 1),
@@ -350,6 +362,14 @@ def test_process_input_specs_uses_nfdump_adapter_for_nfcapd(monkeypatch) -> None
             1744733100,
             'processed',
         )
+    ]
+    assert aggregate_netflow == [
+        ('1d', 4, 1, 10, 1000),
+        ('1d', 6, 1, 3, 300),
+        ('1h', 4, 1, 10, 1000),
+        ('1h', 6, 1, 3, 300),
+        ('30m', 4, 1, 10, 1000),
+        ('30m', 6, 1, 3, 300),
     ]
 
 
@@ -758,6 +778,46 @@ def test_discover_nfcapd_tree_specs_uses_canonical_layout(tmp_path: Path) -> Non
     ]
 
 
+def test_discover_nfcapd_tree_specs_zero_fills_bounded_missing_buckets(tmp_path: Path) -> None:
+    pipeline_v2, _ = load_modules()
+    root = tmp_path / 'uoregon'
+    first = root / 'cc_ir1_gw' / '2025' / '02' / '01' / 'nfcapd.202502010000'
+    second = root / 'cc_ir1_gw' / '2025' / '02' / '01' / 'nfcapd.202502010010'
+    for path in [first, second]:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text('', encoding='utf-8')
+
+    specs = pipeline_v2.discover_nfcapd_tree_specs(
+        root_path=root,
+        source_ids=['cc_ir1_gw'],
+        day=datetime(2025, 2, 1),
+        source_bounds=pipeline_v2.discover_nfcapd_source_bounds(root, ['cc_ir1_gw']),
+    )
+
+    assert specs == [
+        {
+            'input_kind': 'nfcapd',
+            'path': str(first),
+            'source_id': 'cc_ir1_gw',
+        },
+        {
+            'input_kind': 'nfcapd',
+            'path': 'gap://nfcapd/cc_ir1_gw/202502010005',
+            'expected_path': str(
+                root / 'cc_ir1_gw' / '2025' / '02' / '01' / 'nfcapd.202502010005'
+            ),
+            'source_id': 'cc_ir1_gw',
+            'bucket_start': pipeline_v2.parse_nfcapd_bucket_start(str(first)) + 300,
+            'gap': True,
+        },
+        {
+            'input_kind': 'nfcapd',
+            'path': str(second),
+            'source_id': 'cc_ir1_gw',
+        },
+    ]
+
+
 def test_process_pipeline_v2_config_chunks_nfcapd_tree_by_day(monkeypatch, tmp_path: Path) -> None:
     pipeline_v2, _ = load_modules()
     conn = sqlite3.connect(':memory:')
@@ -787,6 +847,7 @@ def test_process_pipeline_v2_config_chunks_nfcapd_tree_by_day(monkeypatch, tmp_p
                     'source_ids': ['cc_ir1_gw', 'oh_ir1_gw'],
                     'start_date': '2025-02-01',
                     'end_date': '2025-02-02',
+                    'zero_fill_gaps': False,
                 }
             ],
         },
@@ -825,6 +886,7 @@ def test_process_pipeline_v2_config_defaults_tree_end_date_to_latest_file(
                     'root_path': str(root),
                     'source_ids': ['cc_ir1_gw'],
                     'start_date': '2025-02-01',
+                    'zero_fill_gaps': False,
                 }
             ],
         },
@@ -883,6 +945,75 @@ def test_process_pipeline_v2_config_skips_fully_processed_tree_day(
             ],
         },
     )
+
+
+def test_process_input_specs_writes_zero_rows_for_nfcapd_gap() -> None:
+    pipeline_v2, _ = load_modules()
+    conn = sqlite3.connect(':memory:')
+    bucket_start = 1744733100
+
+    pipeline_v2.process_input_specs(
+        conn,
+        [
+            {
+                'input_kind': 'nfcapd',
+                'path': 'gap://nfcapd/oh_ir1_gw/202504150005',
+                'source_id': 'oh_ir1_gw',
+                'bucket_start': bucket_start,
+                'gap': True,
+            }
+        ],
+        max_workers=1,
+        run_maad=False,
+    )
+
+    processed_inputs = conn.execute(
+        'SELECT input_kind, input_locator, source_id, bucket_start, status FROM processed_inputs_v2'
+    ).fetchall()
+    netflow = conn.execute(
+        'SELECT source_id, bucket_start, ip_version, flows, packets, bytes FROM netflow_stats_v2 ORDER BY ip_version'
+    ).fetchall()
+    aggregate_netflow = conn.execute(
+        """
+        SELECT granularity, ip_version, flows, packets, bytes
+        FROM netflow_stats_aggregate_v2
+        ORDER BY granularity, ip_version
+        """
+    ).fetchall()
+    ip_stats = conn.execute(
+        "SELECT granularity, sa_ipv4_count, da_ipv4_count, sa_ipv6_count, da_ipv6_count FROM ip_stats_v2 ORDER BY granularity"
+    ).fetchall()
+    protocol_stats = conn.execute(
+        "SELECT granularity, protocols_list_ipv4, protocols_list_ipv6 FROM protocol_stats_v2 ORDER BY granularity"
+    ).fetchall()
+
+    assert processed_inputs == [
+        ('nfcapd', 'gap://nfcapd/oh_ir1_gw/202504150005', 'oh_ir1_gw', bucket_start, 'processed')
+    ]
+    assert netflow == [
+        ('oh_ir1_gw', bucket_start, 4, 0, 0, 0),
+        ('oh_ir1_gw', bucket_start, 6, 0, 0, 0),
+    ]
+    assert aggregate_netflow == [
+        ('1d', 4, 0, 0, 0),
+        ('1d', 6, 0, 0, 0),
+        ('1h', 4, 0, 0, 0),
+        ('1h', 6, 0, 0, 0),
+        ('30m', 4, 0, 0, 0),
+        ('30m', 6, 0, 0, 0),
+    ]
+    assert ip_stats == [
+        ('1d', 0, 0, 0, 0),
+        ('1h', 0, 0, 0, 0),
+        ('30m', 0, 0, 0, 0),
+        ('5m', 0, 0, 0, 0),
+    ]
+    assert protocol_stats == [
+        ('1d', '', ''),
+        ('1h', '', ''),
+        ('30m', '', ''),
+        ('5m', '', ''),
+    ]
 
 
 def test_process_input_specs_always_runs_maad(monkeypatch) -> None:

--- a/tools/netflow-db/benchmark_nfcapd_v2.py
+++ b/tools/netflow-db/benchmark_nfcapd_v2.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python3
+"""Benchmark pipeline-v2 nfcapd ingest slices."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import tempfile
+import time
+from collections import defaultdict
+from pathlib import Path
+from typing import Callable
+
+import nfdump_stats_v2
+import pipeline_v2
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description='Benchmark pipeline-v2 nfcapd ingest.')
+    parser.add_argument('--path', action='append', default=[], help='nfcapd file path. Repeatable.')
+    parser.add_argument('--source-id', help='Source id for --path inputs.')
+    parser.add_argument('--root', help='Canonical nfcapd tree root.')
+    parser.add_argument('--day', help='Day for --root discovery, YYYY-MM-DD.')
+    parser.add_argument('--source', action='append', default=[], help='Source id for --root discovery. Repeatable.')
+    parser.add_argument('--limit', type=int, help='Limit discovered/input files.')
+    parser.add_argument('--repeat', type=int, default=1, help='Repeat count.')
+    parser.add_argument('--mode', choices=('payload', 'pipeline'), default='payload')
+    parser.add_argument('--database-path', help='SQLite path for pipeline mode. Defaults to a temp database.')
+    parser.add_argument('--max-workers', type=int, default=1)
+    parser.add_argument('--maad-bin', default=str(pipeline_v2.DEFAULT_MAAD_BIN))
+    parser.add_argument('--maad-backend', default='subprocess')
+    parser.add_argument('--run-maad', action='store_true')
+    parser.add_argument(
+        '--legacy-address-split',
+        action='store_true',
+        help='Benchmark the previous two-command IPv4/IPv6 address extraction shape.',
+    )
+    args = parser.parse_args()
+
+    phase_stats = PhaseTimingStats()
+    specs = phase_stats.time_call('discovery', lambda: build_specs(args))
+    if args.limit is not None:
+        specs = specs[: args.limit]
+    if not specs:
+        raise SystemExit('no nfcapd inputs selected')
+
+    stats = NfdumpTimingStats()
+    patches = [
+        ModulePatch(nfdump_stats_v2, 'run_nfdump', stats.wrap(nfdump_stats_v2.run_nfdump)),
+        ModulePatch(
+            pipeline_v2,
+            'build_nfcapd_bucket_payload',
+            phase_stats.wrap('nfcapd_payload', pipeline_v2.build_nfcapd_bucket_payload),
+        ),
+        ModulePatch(
+            pipeline_v2,
+            'write_input_payload',
+            phase_stats.wrap('sqlite_input_write', pipeline_v2.write_input_payload),
+        ),
+        ModulePatch(
+            pipeline_v2,
+            'write_aggregate_rows',
+            phase_stats.wrap('aggregate_generation_and_write', pipeline_v2.write_aggregate_rows),
+        ),
+        ModulePatch(
+            pipeline_v2,
+            'flush_streaming_aggregate_buckets',
+            phase_stats.wrap('aggregate_generation_and_write', pipeline_v2.flush_streaming_aggregate_buckets),
+        ),
+        ModulePatch(
+            pipeline_v2,
+            'process_maad_row_task',
+            phase_stats.wrap('maad_task', pipeline_v2.process_maad_row_task),
+        ),
+    ]
+    original_read_address_sets_by_version = nfdump_stats_v2.read_address_sets_by_version
+    for patch in patches:
+        patch.apply()
+    if args.legacy_address_split:
+        nfdump_stats_v2.read_address_sets_by_version = read_address_sets_by_version_legacy
+    try:
+        summary = run_benchmark(args, specs, stats, phase_stats)
+    finally:
+        for patch in reversed(patches):
+            patch.restore()
+        nfdump_stats_v2.read_address_sets_by_version = original_read_address_sets_by_version
+
+    print(json.dumps(summary, indent=2, sort_keys=True))
+
+
+def build_specs(args: argparse.Namespace) -> list[dict]:
+    if args.path:
+        if not args.source_id:
+            raise SystemExit('--source-id is required with --path')
+        return [
+            {
+                'input_kind': 'nfcapd',
+                'path': path,
+                'source_id': args.source_id,
+            }
+            for path in args.path
+        ]
+
+    if args.root:
+        if not args.day:
+            raise SystemExit('--day is required with --root')
+        if not args.source:
+            raise SystemExit('--source is required with --root')
+        return pipeline_v2.discover_nfcapd_tree_specs(
+            args.root,
+            args.source,
+            pipeline_v2.parse_config_date(args.day),
+        )
+
+    raise SystemExit('provide --path or --root')
+
+
+class NfdumpTimingStats:
+    def __init__(self) -> None:
+        self.calls = 0
+        self.seconds = 0.0
+        self.by_label: dict[str, dict[str, float | int]] = defaultdict(lambda: {'calls': 0, 'seconds': 0.0})
+
+    def wrap(self, run_nfdump: Callable):
+        def timed_run_nfdump(command: list[str]):
+            label = nfdump_command_label(command)
+            start = time.perf_counter()
+            try:
+                return run_nfdump(command)
+            finally:
+                elapsed = time.perf_counter() - start
+                self.calls += 1
+                self.seconds += elapsed
+                self.by_label[label]['calls'] += 1
+                self.by_label[label]['seconds'] += elapsed
+
+        return timed_run_nfdump
+
+    def snapshot(self) -> dict:
+        return {
+            'calls': self.calls,
+            'seconds': round(self.seconds, 6),
+            'by_label': {
+                label: {
+                    'calls': values['calls'],
+                    'seconds': round(values['seconds'], 6),
+                }
+                for label, values in sorted(self.by_label.items())
+            },
+        }
+
+
+class PhaseTimingStats:
+    def __init__(self) -> None:
+        self.by_label: dict[str, dict[str, float | int]] = defaultdict(lambda: {'calls': 0, 'seconds': 0.0})
+
+    def wrap(self, label: str, function: Callable):
+        def timed_function(*args, **kwargs):
+            return self.time_call(label, lambda: function(*args, **kwargs))
+
+        return timed_function
+
+    def time_call(self, label: str, callback: Callable):
+        start = time.perf_counter()
+        try:
+            return callback()
+        finally:
+            elapsed = time.perf_counter() - start
+            self.by_label[label]['calls'] += 1
+            self.by_label[label]['seconds'] += elapsed
+
+    def snapshot(self) -> dict:
+        return {
+            label: {
+                'calls': values['calls'],
+                'seconds': round(values['seconds'], 6),
+            }
+            for label, values in sorted(self.by_label.items())
+        }
+
+
+class ModulePatch:
+    def __init__(self, module, name: str, replacement) -> None:
+        self.module = module
+        self.name = name
+        self.replacement = replacement
+        self.original = getattr(module, name)
+
+    def apply(self) -> None:
+        setattr(self.module, self.name, self.replacement)
+
+    def restore(self) -> None:
+        setattr(self.module, self.name, self.original)
+
+
+def nfdump_command_label(command: list[str]) -> str:
+    joined = ' '.join(command)
+    if '-A proto' in joined:
+        if 'ipv4' in command:
+            return 'protocol_ipv4'
+        if 'ipv6' in command:
+            return 'protocol_ipv6'
+        return 'protocol'
+    if '-A srcip,dstip' in joined:
+        if 'ipv4' in command:
+            return 'address_ipv4'
+        if 'ipv6' in command:
+            return 'address_ipv6'
+        return 'address_all'
+    return 'other'
+
+
+def read_address_sets_by_version_legacy(path: str) -> tuple[set[str], set[str], set[str], set[str]]:
+    source_ipv4, destination_ipv4 = nfdump_stats_v2.read_address_sets(path, 4)
+    source_ipv6, destination_ipv6 = nfdump_stats_v2.read_address_sets(path, 6)
+    return source_ipv4, destination_ipv4, source_ipv6, destination_ipv6
+
+
+def run_benchmark(
+    args: argparse.Namespace,
+    specs: list[dict],
+    stats: NfdumpTimingStats,
+    phase_stats: PhaseTimingStats,
+) -> dict:
+    start = time.perf_counter()
+    if args.mode == 'payload':
+        payloads = 0
+        for _ in range(args.repeat):
+            for spec in specs:
+                pipeline_v2.build_input_payload(
+                    spec,
+                    args.maad_bin,
+                    maad_backend=args.maad_backend,
+                    run_maad=args.run_maad,
+                )
+                payloads += 1
+        row_counts = {'payloads': payloads}
+    else:
+        row_counts = run_pipeline_benchmark(args, specs)
+    elapsed = time.perf_counter() - start
+    return {
+        'mode': args.mode,
+        'legacy_address_split': args.legacy_address_split,
+        'inputs': len(specs),
+        'repeat': args.repeat,
+        'elapsed_seconds': round(elapsed, 6),
+        'seconds_per_input': round(elapsed / (len(specs) * args.repeat), 6),
+        'row_counts': row_counts,
+        'phases': phase_stats.snapshot(),
+        'nfdump': stats.snapshot(),
+    }
+
+
+def run_pipeline_benchmark(args: argparse.Namespace, specs: list[dict]) -> dict[str, int]:
+    if args.database_path:
+        conn = sqlite3.connect(args.database_path)
+        try:
+            return run_pipeline_iterations(args, specs, conn)
+        finally:
+            conn.close()
+
+    with tempfile.TemporaryDirectory(prefix='nfcapd-v2-bench-') as tmp_dir:
+        conn = sqlite3.connect(str(Path(tmp_dir) / 'netflow.sqlite'))
+        try:
+            return run_pipeline_iterations(args, specs, conn)
+        finally:
+            conn.close()
+
+
+def run_pipeline_iterations(args: argparse.Namespace, specs: list[dict], conn: sqlite3.Connection) -> dict[str, int]:
+    for _ in range(args.repeat):
+        pipeline_v2.process_input_specs(
+            conn,
+            specs,
+            maad_bin=args.maad_bin,
+            maad_backend=args.maad_backend,
+            max_workers=args.max_workers,
+            run_maad=args.run_maad,
+        )
+    return {
+        'processed_inputs_v2': table_count(conn, 'processed_inputs_v2'),
+        'netflow_stats_v2': table_count(conn, 'netflow_stats_v2'),
+        'netflow_stats_aggregate_v2': table_count(conn, 'netflow_stats_aggregate_v2'),
+        'ip_stats_v2': table_count(conn, 'ip_stats_v2'),
+        'protocol_stats_v2': table_count(conn, 'protocol_stats_v2'),
+        'structure_stats_v2': table_count(conn, 'structure_stats_v2'),
+    }
+
+
+def table_count(conn: sqlite3.Connection, table_name: str) -> int:
+    return int(conn.execute(f'SELECT COUNT(*) FROM {table_name}').fetchone()[0])
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/netflow-db/extract_ml_window.py
+++ b/tools/netflow-db/extract_ml_window.py
@@ -7,88 +7,84 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sqlite3
 import sys
 from collections.abc import Sequence
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any
+from zoneinfo import ZoneInfo
+
+
+def v2_table(granularity_column: str | None = None) -> dict[str, str | None]:
+    return {
+        "time_column": "bucket_start",
+        "source_column": "source_id",
+        "granularity_column": granularity_column,
+    }
 
 
 TABLE_CONFIG = {
-    "netflow_stats": {"time_column": "timestamp", "extra_where": "", "extra_params": ()},
-    "ip_stats": {"time_column": "bucket_start", "extra_where": "AND granularity = ?", "extra_params": ("5m",)},
-    "protocol_stats": {"time_column": "bucket_start", "extra_where": "AND granularity = ?", "extra_params": ("5m",)},
-    "spectrum_stats": {"time_column": "bucket_start", "extra_where": "AND granularity = ?", "extra_params": ("5m",)},
-    "structure_stats": {"time_column": "bucket_start", "extra_where": "AND granularity = ?", "extra_params": ("5m",)},
+    "datasets": {"time_column": None, "source_column": None, "granularity_column": None},
+    "processed_inputs_v2": v2_table(),
+    "netflow_stats_v2": v2_table(),
+    "netflow_stats_aggregate_v2": v2_table("granularity"),
+    "ip_stats_v2": v2_table("granularity"),
+    "protocol_stats_v2": v2_table("granularity"),
+    "structure_stats_v2": v2_table("granularity"),
+    "spectrum_stats_v2": v2_table("granularity"),
+    "dimension_stats_v2": v2_table("granularity"),
 }
 
-DEFAULT_START = "2025-03-30"
-DEFAULT_END_INCLUSIVE = "2025-06-07"
-DEFAULT_OUTPUT_DIR = "data/uoregon/ml-2025-03-30-to-2025-06-07"
+DEFAULT_DATASET_ID = "uoregon"
+DEFAULT_START = "2025-05-01"
+DEFAULT_END_EXCLUSIVE = "2026-05-01"
+DEFAULT_OUTPUT_DIR = "data/uoregon-v2/ml-2025-05-01-to-2026-05-01"
 SQLITE_FILENAME = "netflow_window.sqlite"
+DEFAULT_TIMEZONE = os.environ.get("NETFLOW_TIMEZONE", "America/Los_Angeles")
 
 
-def resolve_default_source_db() -> str:
+def resolve_default_source_db(dataset_id: str) -> str:
     try:
         from common import get_dataset_db_path
-        return str(get_dataset_db_path("uoregon"))
+
+        return str(get_dataset_db_path(dataset_id))
     except Exception as error:
         raise SystemExit(f"Could not resolve default source DB: {error}") from error
 
 
 def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
-    parser = argparse.ArgumentParser(
-        description="Extract a fixed NetFlow window for ML workflows.",
-    )
+    parser = argparse.ArgumentParser(description="Extract a fixed NetFlow window for ML workflows.")
+    parser.add_argument("--source-id", help="Only extract rows for a single v2 source_id.")
+    parser.add_argument("--router", help="Alias for --source-id.")
+    parser.add_argument("--dataset", default=DEFAULT_DATASET_ID, help="Dataset id for default DB lookup.")
+    parser.add_argument("--source-db", default=None, help="Path to the source SQLite database.")
+    parser.add_argument("--output-dir", default=DEFAULT_OUTPUT_DIR, help="Output directory.")
+    parser.add_argument("--start", default=DEFAULT_START, help="Inclusive start date in YYYY-MM-DD.")
+    parser.add_argument("--end-exclusive", default=DEFAULT_END_EXCLUSIVE, help="Exclusive end date.")
+    parser.add_argument("--end-inclusive", default=None, help="Legacy inclusive end date.")
+    parser.add_argument("--timezone", default=DEFAULT_TIMEZONE, help="Timezone for date boundaries.")
+    parser.add_argument("--batch-size", type=int, default=5000, help="Fetch/insert batch size.")
+    parser.add_argument("--skip-sqlite", action="store_true", help="Skip SQLite output.")
+    parser.add_argument("--skip-parquet", action="store_true", help="Skip Parquet output.")
     parser.add_argument(
-        "--router",
-        help="Only extract rows for a single router.",
-    )
-    parser.add_argument(
-        "--source-db",
-        default=None,
-        help="Path to the source SQLite database.",
-    )
-    parser.add_argument(
-        "--output-dir",
-        default=DEFAULT_OUTPUT_DIR,
-        help="Directory for the extracted SQLite, Parquet, and manifest outputs.",
-    )
-    parser.add_argument(
-        "--start",
-        default=DEFAULT_START,
-        help="Inclusive window start date in YYYY-MM-DD.",
-    )
-    parser.add_argument(
-        "--end-inclusive",
-        default=DEFAULT_END_INCLUSIVE,
-        help="Inclusive window end date in YYYY-MM-DD.",
-    )
-    parser.add_argument(
-        "--batch-size",
-        type=int,
-        default=5000,
-        help="Fetch/insert batch size.",
-    )
-    parser.add_argument(
-        "--skip-sqlite",
-        action="store_true",
-        help="Skip writing the extracted SQLite database.",
-    )
-    parser.add_argument(
-        "--skip-parquet",
-        action="store_true",
-        help="Skip writing Parquet files.",
-    )
-    parser.add_argument(
-        "--all-granularities",
-        action="store_true",
-        help="Include non-5m rows from derived tables.",
+        "--granularity",
+        action="append",
+        choices=("5m", "30m", "1h", "1d"),
+        help="Limit tables with a granularity column. Repeat for multiple granularities.",
     )
     args = parser.parse_args(argv)
+    if args.source_id is not None and args.router is not None and args.source_id != args.router:
+        raise SystemExit("--source-id and --router must match when both are provided.")
+    args.source_id = args.source_id or args.router
+    if args.end_inclusive is not None:
+        if args.end_exclusive != DEFAULT_END_EXCLUSIVE:
+            raise SystemExit("Use only one of --end-exclusive or --end-inclusive.")
+        end_inclusive_dt = parse_date(args.end_inclusive)
+        args.end_exclusive = (end_inclusive_dt + timedelta(days=1)).strftime("%Y-%m-%d")
     if args.source_db is None:
-        args.source_db = resolve_default_source_db()
+        args.source_db = resolve_default_source_db(args.dataset)
     return args
 
 
@@ -96,13 +92,13 @@ def parse_date(date_str: str) -> datetime:
     return datetime.strptime(date_str, "%Y-%m-%d")
 
 
-def compute_window(start_date: str, end_inclusive: str) -> tuple[datetime, datetime, int, int]:
-    start_dt = parse_date(start_date)
-    end_dt = parse_date(end_inclusive)
-    if end_dt < start_dt:
-        raise SystemExit("--end-inclusive must be on or after --start")
+def compute_window(start_date: str, end_exclusive: str, timezone: str) -> tuple[datetime, datetime, int, int]:
+    tzinfo = ZoneInfo(timezone)
+    start_dt = parse_date(start_date).replace(tzinfo=tzinfo)
+    end_exclusive_dt = parse_date(end_exclusive).replace(tzinfo=tzinfo)
+    if end_exclusive_dt <= start_dt:
+        raise SystemExit("--end-exclusive must be after --start")
 
-    end_exclusive_dt = end_dt + timedelta(days=1)
     return start_dt, end_exclusive_dt, int(start_dt.timestamp()), int(end_exclusive_dt.timestamp())
 
 
@@ -120,20 +116,22 @@ def connect_db(path: Path) -> sqlite3.Connection:
 
 def build_table_filters(
     *,
-    router: str | None,
-    all_granularities: bool,
+    source_id: str | None,
+    granularities: list[str] | None,
     config: dict[str, Any],
 ) -> tuple[str, tuple[Any, ...]]:
     clauses: list[str] = []
     params: list[Any] = []
 
-    if not all_granularities and config["extra_where"]:
-        clauses.append(str(config["extra_where"]).removeprefix("AND ").strip())
-        params.extend(config["extra_params"])
+    granularity_column = config["granularity_column"]
+    if granularities is not None and granularity_column is not None:
+        clauses.append(f"{granularity_column} IN ({', '.join(['?'] * len(granularities))})")
+        params.extend(granularities)
 
-    if router is not None:
-        clauses.append("router = ?")
-        params.append(router)
+    source_column = config["source_column"]
+    if source_id is not None and source_column is not None:
+        clauses.append(f"{source_column} = ?")
+        params.append(source_id)
 
     extra_where = ""
     if clauses:
@@ -173,22 +171,24 @@ def create_sqlite_table(source_conn: sqlite3.Connection, dest_conn: sqlite3.Conn
 def iter_table_batches(
     conn: sqlite3.Connection,
     table: str,
-    time_column: str,
+    time_column: str | None,
     start_ts: int,
     end_ts: int,
     batch_size: int,
     extra_where: str = "",
     extra_params: tuple[Any, ...] = (),
 ):
-    cursor = conn.execute(
-        f"""
-        SELECT *
-        FROM {table}
-        WHERE {time_column} >= ? AND {time_column} < ?
-        {extra_where}
-        """,
-        (start_ts, end_ts, *extra_params),
-    )
+    clauses: list[str] = []
+    params: list[Any] = []
+    if time_column is not None:
+        clauses.append(f"{time_column} >= ? AND {time_column} < ?")
+        params.extend((start_ts, end_ts))
+    if extra_where:
+        clauses.append(extra_where.removeprefix("AND ").strip())
+        params.extend(extra_params)
+
+    where_sql = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+    cursor = conn.execute(f"SELECT * FROM {table} {where_sql}", tuple(params))
 
     while True:
         rows = cursor.fetchmany(batch_size)
@@ -201,7 +201,7 @@ def copy_table_to_sqlite(
     source_conn: sqlite3.Connection,
     dest_conn: sqlite3.Connection,
     table: str,
-    time_column: str,
+    time_column: str | None,
     start_ts: int,
     end_ts: int,
     batch_size: int,
@@ -238,7 +238,7 @@ def export_table_to_parquet(
     source_conn: sqlite3.Connection,
     output_path: Path,
     table: str,
-    time_column: str,
+    time_column: str | None,
     start_ts: int,
     end_ts: int,
     batch_size: int,
@@ -294,22 +294,30 @@ def export_table_to_parquet(
 def collect_table_summary(
     conn: sqlite3.Connection,
     table: str,
-    time_column: str,
+    time_column: str | None,
     start_ts: int,
     end_ts: int,
     extra_where: str = "",
     extra_params: tuple[Any, ...] = (),
 ) -> dict[str, Any]:
+    clauses: list[str] = []
+    params: list[Any] = []
+    if time_column is not None:
+        clauses.append(f"{time_column} >= ? AND {time_column} < ?")
+        params.extend((start_ts, end_ts))
+    if extra_where:
+        clauses.append(extra_where.removeprefix("AND ").strip())
+        params.extend(extra_params)
+
+    where_sql = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+    time_select = (
+        f"MIN({time_column}) AS min_time, MAX({time_column}) AS max_time"
+        if time_column is not None
+        else "NULL AS min_time, NULL AS max_time"
+    )
     row = conn.execute(
-        f"""
-        SELECT COUNT(*) AS row_count,
-               MIN({time_column}) AS min_time,
-               MAX({time_column}) AS max_time
-        FROM {table}
-        WHERE {time_column} >= ? AND {time_column} < ?
-        {extra_where}
-        """,
-        (start_ts, end_ts, *extra_params),
+        f"SELECT COUNT(*) AS row_count, {time_select} FROM {table} {where_sql}",
+        tuple(params),
     ).fetchone()
 
     return {
@@ -326,16 +334,21 @@ def build_manifest(
     end_exclusive_dt: datetime,
     start_ts: int,
     end_ts: int,
+    timezone: str,
+    source_id: str | None,
+    granularities: list[str] | None,
     tables: dict[str, dict[str, Any]],
 ) -> dict[str, Any]:
     return {
         "source_db": str(source_db),
         "output_dir": str(output_dir),
         "start_date": start_dt.strftime("%Y-%m-%d"),
-        "end_inclusive_date": (end_exclusive_dt - timedelta(days=1)).strftime("%Y-%m-%d"),
         "end_exclusive_date": end_exclusive_dt.strftime("%Y-%m-%d"),
         "start_ts": start_ts,
         "end_exclusive_ts": end_ts,
+        "timezone": timezone,
+        "source_id_filter": source_id,
+        "granularity_filter": granularities,
         "tables": tables,
     }
 
@@ -364,7 +377,11 @@ def main() -> None:
     if not args.skip_parquet:
         parquet_dir.mkdir(parents=True, exist_ok=True)
 
-    start_dt, end_exclusive_dt, start_ts, end_ts = compute_window(args.start, args.end_inclusive)
+    start_dt, end_exclusive_dt, start_ts, end_ts = compute_window(
+        args.start,
+        args.end_exclusive,
+        args.timezone,
+    )
 
     manifest_tables: dict[str, dict[str, Any]] = {}
     sqlite_output_path = output_dir / SQLITE_FILENAME
@@ -378,15 +395,12 @@ def main() -> None:
                 dest_conn = connect_db(sqlite_output_path)
 
             for table, config in TABLE_CONFIG.items():
-                time_column = str(config["time_column"])
+                time_column = config["time_column"]
                 extra_where, extra_params = build_table_filters(
-                    router=args.router,
-                    all_granularities=args.all_granularities,
+                    source_id=args.source_id,
+                    granularities=args.granularity,
                     config=config,
                 )
-                granularity_filter = None
-                if not args.all_granularities and config["extra_params"]:
-                    granularity_filter = config["extra_params"][0]
                 summary = collect_table_summary(
                     source_conn,
                     table,
@@ -399,8 +413,8 @@ def main() -> None:
 
                 table_manifest = {
                     "time_column": time_column,
-                    "router_filter": args.router,
-                    "granularity_filter": granularity_filter,
+                    "source_id_filter": args.source_id,
+                    "granularity_filter": args.granularity if config["granularity_column"] else None,
                     "source_row_count": summary["row_count"],
                     "source_min_time": summary["min_time"],
                     "source_max_time": summary["max_time"],
@@ -462,6 +476,9 @@ def main() -> None:
         end_exclusive_dt=end_exclusive_dt,
         start_ts=start_ts,
         end_ts=end_ts,
+        timezone=args.timezone,
+        source_id=args.source_id,
+        granularities=args.granularity,
         tables=manifest_tables,
     )
     manifest_path = write_manifest(output_dir, manifest)

--- a/tools/netflow-db/nfdump_stats_v2.py
+++ b/tools/netflow-db/nfdump_stats_v2.py
@@ -11,6 +11,7 @@ import csv
 import ipaddress
 import logging
 import os
+import re
 import subprocess
 from datetime import datetime
 from pathlib import Path
@@ -22,6 +23,7 @@ from stats_v2 import protocol_metric_keys
 NFDUMP_TIMEOUT_SECONDS = 300
 PIPELINE_TIMEZONE = ZoneInfo(os.environ.get('NETFLOW_TIMEZONE', 'America/Los_Angeles'))
 LOGGER = logging.getLogger(__name__)
+NFCAPD_FILENAME_RE = re.compile(r'^nfcapd\.(\d{12})$')
 
 
 def build_nfcapd_bucket_payload(path: str, source_id: str) -> dict:
@@ -78,6 +80,11 @@ def build_nfcapd_bucket_payload(path: str, source_id: str) -> dict:
             'netflow_rows': [strip_internal_keys(netflow_ipv4), strip_internal_keys(netflow_ipv6)],
         },
     }
+
+
+def is_nfcapd_bucket_filename(name: str) -> bool:
+    """Return true for canonical nfcapd bucket filenames."""
+    return NFCAPD_FILENAME_RE.fullmatch(name) is not None
 
 
 def read_protocol_netflow_row(
@@ -270,9 +277,10 @@ def family_filter(ip_version: int) -> list[str]:
 def parse_nfcapd_bucket_start(path: str) -> int:
     """Parse the local-time 5m bucket from an nfcapd filename."""
     name = Path(path).name
-    if not name.startswith('nfcapd.'):
+    match = NFCAPD_FILENAME_RE.fullmatch(name)
+    if match is None:
         raise ValueError(f'Invalid nfcapd filename: {name}')
-    timestamp = name.split('.', 1)[1]
+    timestamp = match.group(1)
     local_time = datetime.strptime(timestamp, '%Y%m%d%H%M')
     # Ambiguous fall-back labels cannot distinguish both folds. Canonical nfcapd
     # paths contain one file per local 5m label, so use the first fold.

--- a/tools/netflow-db/nfdump_stats_v2.py
+++ b/tools/netflow-db/nfdump_stats_v2.py
@@ -30,8 +30,7 @@ def build_nfcapd_bucket_payload(path: str, source_id: str) -> dict:
     """Build 5m stats and raw aggregate sets for one nfcapd file."""
     bucket_start = parse_nfcapd_bucket_start(path)
     bucket_end = bucket_start + 300
-    source_ipv4, destination_ipv4 = read_address_sets(path, 4)
-    source_ipv6, destination_ipv6 = read_address_sets(path, 6)
+    source_ipv4, destination_ipv4, source_ipv6, destination_ipv6 = read_address_sets_by_version(path)
     netflow_ipv4 = read_protocol_netflow_row(path, source_id, bucket_start, bucket_end, 4)
     netflow_ipv6 = read_protocol_netflow_row(path, source_id, bucket_start, bucket_end, 6)
     protocols_ipv4 = protocols_from_netflow_row(netflow_ipv4)
@@ -185,6 +184,48 @@ def parse_protocol_counter_row(
         return None
 
     return (protocol, packets, bytes_value, flows)
+
+
+def read_address_sets_by_version(path: str) -> tuple[set[str], set[str], set[str], set[str]]:
+    """Read unique grouped source and destination address sets split by IP version."""
+    result = run_nfdump(
+        [
+            'nfdump',
+            '-r',
+            path,
+            '-q',
+            '-a',
+            '-A',
+            'srcip,dstip',
+            '-o',
+            'fmt:%sa,%da',
+        ]
+    )
+    source_ipv4 = set()
+    destination_ipv4 = set()
+    source_ipv6 = set()
+    destination_ipv6 = set()
+    for values in csv.reader(result.stdout.splitlines()):
+        if len(values) < 2:
+            continue
+        source_ip = values[0].strip()
+        destination_ip = values[1].strip()
+        if looks_like_ipv4_address(source_ip) and looks_like_ipv4_address(destination_ip):
+            source_ipv4.add(source_ip)
+            destination_ipv4.add(destination_ip)
+            continue
+        if ':' in source_ip and ':' in destination_ip:
+            try:
+                source_ipv6.add(str(ipaddress.ip_address(source_ip)))
+                destination_ipv6.add(str(ipaddress.ip_address(destination_ip)))
+            except ValueError:
+                continue
+    return source_ipv4, destination_ipv4, source_ipv6, destination_ipv6
+
+
+def looks_like_ipv4_address(value: str) -> bool:
+    """Return true for trusted nfdump IPv4 address text."""
+    return bool(value) and '.' in value and all(char.isdigit() or char == '.' for char in value)
 
 
 def read_address_sets(path: str, ip_version: int) -> tuple[set[str], set[str]]:

--- a/tools/netflow-db/pipeline_v2.py
+++ b/tools/netflow-db/pipeline_v2.py
@@ -55,7 +55,7 @@ from maad_v2 import (
     insert_maad_v2_rows,
     run_maad_json,
 )
-from nfdump_stats_v2 import build_nfcapd_bucket_payload
+from nfdump_stats_v2 import build_nfcapd_bucket_payload, is_nfcapd_bucket_filename
 from normalized_rows_v2 import NormalizedRow, build_nfdump_csv_command, normalize_nfdump_csv_values
 from normalized_rows_v2 import infer_ip_version
 from processed_inputs_v2 import (
@@ -389,6 +389,8 @@ def discover_nfcapd_tree_specs(
         if not day_dir.is_dir():
             continue
         for path in sorted(day_dir.glob('nfcapd.*')):
+            if not is_nfcapd_bucket_filename(path.name):
+                continue
             specs.append(
                 {
                     'input_kind': 'nfcapd',

--- a/tools/netflow-db/pipeline_v2.py
+++ b/tools/netflow-db/pipeline_v2.py
@@ -55,7 +55,11 @@ from maad_v2 import (
     insert_maad_v2_rows,
     run_maad_json,
 )
-from nfdump_stats_v2 import build_nfcapd_bucket_payload, is_nfcapd_bucket_filename
+from nfdump_stats_v2 import (
+    build_nfcapd_bucket_payload,
+    is_nfcapd_bucket_filename,
+    parse_nfcapd_bucket_start,
+)
 from normalized_rows_v2 import NormalizedRow, build_nfdump_csv_command, normalize_nfdump_csv_values
 from normalized_rows_v2 import infer_ip_version
 from processed_inputs_v2 import (
@@ -81,6 +85,7 @@ DEFAULT_MAAD_BIN = Path(__file__).resolve().parent / 'maad_fast'
 DEFAULT_MAX_WORKERS = int(os.environ.get('MAX_WORKERS', '8'))
 DEFAULT_AGGREGATE_MAAD_MAX_WORKERS = int(os.environ.get('AGGREGATE_MAAD_MAX_WORKERS', '4'))
 PIPELINE_TIMEZONE = ZoneInfo(os.environ.get('NETFLOW_TIMEZONE', 'America/Los_Angeles'))
+FIVE_MINUTE_SECONDS = 300
 ARROW_IPV4_REGEX = (
     r'^(?:[0-9]{1,2}|0[0-9]{2}|1[0-9]{2}|2[0-4][0-9]|25[0-5])'
     r'(?:\.(?:[0-9]{1,2}|0[0-9]{2}|1[0-9]{2}|2[0-4][0-9]|25[0-5])){3}$'
@@ -326,9 +331,16 @@ def process_nfcapd_tree_spec(
         if spec.get('end_date')
         else discover_latest_nfcapd_tree_day(root_path, source_ids)
     )
+    zero_fill_gaps = bool(spec.get('zero_fill_gaps', True))
+    source_bounds = discover_nfcapd_source_bounds(root_path, source_ids) if zero_fill_gaps else {}
 
     for day in iter_days(start_date, end_date):
-        input_specs = discover_nfcapd_tree_specs(root_path, source_ids, day)
+        input_specs = discover_nfcapd_tree_specs(
+            root_path,
+            source_ids,
+            day,
+            source_bounds=source_bounds,
+        )
         if not input_specs:
             LOGGER.info('No nfcapd files found for %s', day.strftime('%Y-%m-%d'))
             continue
@@ -380,25 +392,100 @@ def discover_nfcapd_tree_specs(
     root_path: str | Path,
     source_ids: list[str],
     day: datetime,
+    *,
+    source_bounds: dict[str, tuple[int, int]] | None = None,
 ) -> list[dict]:
-    """Discover nfcapd files under <root>/<source>/YYYY/MM/DD."""
+    """Discover nfcapd files and bounded gap buckets under <root>/<source>/YYYY/MM/DD."""
     root = Path(root_path)
     specs = []
     for source_id in sorted(source_ids):
         day_dir = root / source_id / day.strftime('%Y') / day.strftime('%m') / day.strftime('%d')
-        if not day_dir.is_dir():
-            continue
-        for path in sorted(day_dir.glob('nfcapd.*')):
-            if not is_nfcapd_bucket_filename(path.name):
-                continue
-            specs.append(
-                {
+        real_specs = {}
+        if day_dir.is_dir():
+            for path in sorted(day_dir.glob('nfcapd.*')):
+                if not is_nfcapd_bucket_filename(path.name):
+                    continue
+                real_specs[parse_nfcapd_bucket_start(str(path))] = {
                     'input_kind': 'nfcapd',
                     'path': str(path),
                     'source_id': source_id,
                 }
-            )
+        if source_bounds is None or source_id not in source_bounds:
+            specs.extend(real_specs[bucket_start] for bucket_start in sorted(real_specs))
+            continue
+
+        first_bucket, last_bucket = source_bounds[source_id]
+        for bucket_start in iter_local_day_bucket_starts(day):
+            spec = real_specs.get(bucket_start)
+            if spec is not None:
+                specs.append(spec)
+            elif first_bucket < bucket_start < last_bucket:
+                specs.append(build_nfcapd_gap_spec(root, source_id, bucket_start))
     return specs
+
+
+def discover_nfcapd_source_bounds(
+    root_path: str | Path,
+    source_ids: list[str],
+) -> dict[str, tuple[int, int]]:
+    """Return first and last real nfcapd bucket per source."""
+    root = Path(root_path)
+    bounds: dict[str, tuple[int, int]] = {}
+    for source_id in source_ids:
+        bucket_starts = [
+            parse_nfcapd_bucket_start(str(path))
+            for path in iter_nfcapd_source_paths(root / source_id)
+        ]
+        if bucket_starts:
+            bounds[source_id] = (min(bucket_starts), max(bucket_starts))
+    return bounds
+
+
+def iter_nfcapd_source_paths(source_root: Path) -> Iterable[Path]:
+    """Yield canonical nfcapd files below one source root."""
+    if not source_root.is_dir():
+        return
+    for year_dir in sorted(source_root.glob('????')):
+        if not year_dir.is_dir():
+            continue
+        for month_dir in sorted(year_dir.glob('??')):
+            if not month_dir.is_dir():
+                continue
+            for day_dir in sorted(month_dir.glob('??')):
+                if not day_dir.is_dir():
+                    continue
+                for path in sorted(day_dir.glob('nfcapd.*')):
+                    if is_nfcapd_bucket_filename(path.name):
+                        yield path
+
+
+def iter_local_day_bucket_starts(day: datetime) -> Iterable[int]:
+    """Yield local-time 5m bucket starts for one calendar day."""
+    current = day.replace(tzinfo=PIPELINE_TIMEZONE)
+    end = current + timedelta(days=1)
+    while current < end:
+        yield int(current.timestamp())
+        current += timedelta(seconds=FIVE_MINUTE_SECONDS)
+
+
+def build_nfcapd_gap_spec(root: Path, source_id: str, bucket_start: int) -> dict:
+    """Build an internal zero-fill spec for one missing nfcapd bucket."""
+    timestamp = datetime.fromtimestamp(bucket_start, PIPELINE_TIMEZONE)
+    return {
+        'input_kind': 'nfcapd',
+        'path': f"gap://nfcapd/{source_id}/{timestamp.strftime('%Y%m%d%H%M')}",
+        'expected_path': str(
+            root
+            / source_id
+            / timestamp.strftime('%Y')
+            / timestamp.strftime('%m')
+            / timestamp.strftime('%d')
+            / f"nfcapd.{timestamp.strftime('%Y%m%d%H%M')}"
+        ),
+        'source_id': source_id,
+        'bucket_start': bucket_start,
+        'gap': True,
+    }
 
 
 def all_tree_specs_processed(conn: sqlite3.Connection, input_specs: list[dict]) -> bool:
@@ -543,6 +630,18 @@ def process_input_specs(
         )
         return
 
+    if should_stream_nfcapd_input_specs(input_specs):
+        process_nfcapd_input_specs_streaming_aggregates(
+            conn,
+            input_specs,
+            maad_bin=maad_bin,
+            maad_backend=maad_backend,
+            maad_workers=maad_workers,
+            max_workers=max_workers,
+            run_maad=run_maad,
+        )
+        return
+
     tasks = [(spec, str(maad_bin), maad_backend, maad_workers, run_maad) for spec in input_specs]
     processed_buckets = []
     raw_buckets = []
@@ -560,6 +659,46 @@ def process_input_specs(
         maad_backend=maad_backend,
         maad_workers=maad_workers,
         run_maad=run_maad,
+    )
+    with conn:
+        mark_processed_buckets(conn, processed_buckets)
+
+
+def should_stream_nfcapd_input_specs(input_specs: list[dict]) -> bool:
+    """Return true when every input spec is a native nfcapd bucket."""
+    return bool(input_specs) and all(str(spec['input_kind']) == 'nfcapd' for spec in input_specs)
+
+
+def process_nfcapd_input_specs_streaming_aggregates(
+    conn: sqlite3.Connection,
+    input_specs: list[dict],
+    *,
+    maad_bin: str | Path,
+    maad_backend: str,
+    maad_workers: int,
+    max_workers: int,
+    run_maad: bool,
+) -> None:
+    """Process nfcapd inputs without retaining every raw 5m address payload."""
+    tasks = [(spec, str(maad_bin), maad_backend, maad_workers, run_maad) for spec in input_specs]
+    processed_buckets = []
+    aggregate_buckets: dict[tuple[str, str, int], dict] = {}
+
+    for payload in iter_input_payloads(tasks, max_workers):
+        write_input_payload(conn, payload, mark_processed=False)
+        processed_buckets.extend(payload['processed_buckets'])
+        for raw_bucket in payload.get('raw_buckets', []):
+            add_raw_bucket_to_streaming_aggregates(aggregate_buckets, raw_bucket)
+
+    aggregate_workers = aggregate_maad_worker_count(max(max_workers, maad_workers))
+    flush_streaming_aggregate_buckets(
+        conn,
+        aggregate_buckets,
+        list(aggregate_buckets),
+        maad_bin,
+        maad_backend,
+        aggregate_workers,
+        run_maad,
     )
     with conn:
         mark_processed_buckets(conn, processed_buckets)
@@ -1858,6 +1997,13 @@ def build_input_payload(
     input_kind = str(spec['input_kind'])
     input_locator = str(spec['path'])
     if input_kind == 'nfcapd':
+        if spec.get('gap'):
+            return build_nfcapd_gap_payload(
+                input_locator=input_locator,
+                source_id=str(spec['source_id']),
+                bucket_start=int(spec['bucket_start']),
+                run_maad=run_maad,
+            )
         nfcapd_payload = build_nfcapd_bucket_payload(input_locator, str(spec['source_id']))
         return {
             'processed_buckets': [nfcapd_payload['processed_bucket']],
@@ -2269,6 +2415,79 @@ def iter_input_rows(spec: dict) -> Iterable[NormalizedRow]:
         yield from iter_nfdump_rows(input_path, source_id)
         return
     raise ValueError(f'Unsupported input_kind: {input_kind}')
+
+
+def build_nfcapd_gap_payload(
+    input_locator: str,
+    source_id: str,
+    bucket_start: int,
+    *,
+    run_maad: bool = True,
+) -> dict:
+    """Build zero-valued v2 rows for one bounded missing nfcapd bucket."""
+    bucket_end = bucket_start + FIVE_MINUTE_SECONDS
+    netflow_rows = [
+        new_netflow_bucket_from_values(
+            source_id=source_id,
+            bucket_start=bucket_start,
+            bucket_end=bucket_end,
+            ip_version=ip_version,
+        )
+        for ip_version in (4, 6)
+    ]
+    raw_bucket = {
+        'source_id': source_id,
+        'bucket_start': bucket_start,
+        'source_ipv4': [],
+        'destination_ipv4': [],
+        'source_ipv6': [],
+        'destination_ipv6': [],
+        'protocols_ipv4': [],
+        'protocols_ipv6': [],
+        'maad_source_ipv4': [],
+        'maad_destination_ipv4': [],
+        'netflow_rows': [dict(row) for row in netflow_rows],
+    }
+    return {
+        'processed_buckets': [
+            {
+                'input_kind': 'nfcapd',
+                'input_locator': input_locator,
+                'source_id': source_id,
+                'bucket_start': bucket_start,
+                'bucket_end': bucket_end,
+            }
+        ],
+        'netflow_rows': netflow_rows,
+        'ip_rows': [
+            {
+                'source_id': source_id,
+                'granularity': '5m',
+                'bucket_start': bucket_start,
+                'bucket_end': bucket_end,
+                'sa_ipv4_count': 0,
+                'da_ipv4_count': 0,
+                'sa_ipv6_count': 0,
+                'da_ipv6_count': 0,
+            }
+        ],
+        'protocol_rows': [
+            {
+                'source_id': source_id,
+                'granularity': '5m',
+                'bucket_start': bucket_start,
+                'bucket_end': bucket_end,
+                'unique_protocols_count_ipv4': 0,
+                'unique_protocols_count_ipv6': 0,
+                'protocols_list_ipv4': '',
+                'protocols_list_ipv6': '',
+            }
+        ],
+        'maad_rows': [build_maad_rows_for_raw_bucket(raw_bucket, '5m', '', maad_backend='python')]
+        if run_maad
+        else [],
+        'raw_buckets': [raw_bucket],
+    }
 
 
 def accumulate_input_buckets(rows: Iterable[NormalizedRow]) -> dict[tuple[str, int, int], BucketAccumulator]:


### PR DESCRIPTION
Add bounded nfcapd zero-fill gap inputs so missing 5-minute buckets keep zero rows without affecting cumulative buckets.

Keep gap inputs under input_kind=nfcapd with gap:// locators so live DBs can migrate in place.